### PR TITLE
my_cargo on mac

### DIFF
--- a/docker/scripts/my_cargo
+++ b/docker/scripts/my_cargo
@@ -1,7 +1,7 @@
 #!/bin/sh 
 # shellcheck disable=SC2068
 
-mkdir -p ${HOME}/.cargo/registry
+mkdir -p "${HOME}/.cargo/registry"
 
 # Use rbuilder image to compile the source. All package and cargo cache are mapped on
 # host's user folder. It also maps the .git-credential user file from the user in order


### PR DESCRIPTION
Fix my_cargo on mac where group doesn't provide a correct HOME definition. Moreover in a system where local ~/.cargo/registry folder dosn't exit the container folder become a root folder.