### PR TITLE
Initial integration of Proof-of-Stake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4098,6 +4098,7 @@ dependencies = [
  "hp-poe",
  "jsonrpsee",
  "nh-runtime",
+ "pallet-im-online",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc",
  "proof-of-existence-rpc",
@@ -4513,13 +4514,13 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
- "pallet-election-provider-multi-phase",
  "pallet-grandpa",
+ "pallet-im-online",
+ "pallet-offences",
  "pallet-poe",
  "pallet-session",
  "pallet-settlement-fflonk",
  "pallet-staking",
- "pallet-staking-reward-curve",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -4773,45 +4774,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-election-provider-multi-phase"
-version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f6303bbd336414959861b9a530f53e295d66f8d27dd8bd626daaf8fa051a1f"
-dependencies = [
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
- "log",
- "pallet-election-provider-support-benchmarking",
- "parity-scale-codec",
- "rand 0.8.5",
- "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-npos-elections",
- "sp-runtime",
- "sp-std",
- "strum 0.24.1",
-]
-
-[[package]]
-name = "pallet-election-provider-support-benchmarking"
-version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa4d9a426c024e1aa3bb6adbb03aa3b6887be8775e3fba0abda48ca9b17c864"
-dependencies = [
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-system",
- "parity-scale-codec",
- "sp-npos-elections",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-grandpa"
 version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4831,6 +4793,45 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-session",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-im-online"
+version = "26.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273b6bd0c0f098b935714a59f9487e64382e87de49a7cf6d6dd8cdeb63be0aed"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-offences"
+version = "26.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77352f9a1afcde5d36395c9847e14c75d73c379e4f9ff7643f5d64741f20587"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-runtime",
  "sp-staking",
  "sp-std",
 ]
@@ -4919,18 +4920,6 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-std",
-]
-
-[[package]]
-name = "pallet-staking-reward-curve"
-version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efca5a4a423427d2c83af5fe07ab648c16b91e3782c3cc23316fe0bd96b4c794"
-dependencies = [
- "proc-macro-crate 3.1.0",
- "proc-macro2",
- "quote",
- "syn 2.0.52",
 ]
 
 [[package]]
@@ -5434,15 +5423,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
  "toml_edit 0.20.2",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
-dependencies = [
- "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -8968,17 +8948,6 @@ dependencies = [
  "indexmap 2.2.5",
  "serde",
  "serde_spanned",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,20 +40,19 @@ pallet-transaction-payment = { default-features = false, version = "27.0.0" }
 
 sp-io = { default-features = false, version = "29.0.0" }
 sp-timestamp = { default-features = false, version = "25.0.0" }
-sp-keyring = { default-features = false, version = "30.0.0" }
+sp-keyring = { version = "30.0.0" }
 
 pallet-settlement-fflonk = { path = "pallets/settlement-fflonk", default-features = false }
 pallet-poe = { path= "pallets/proof_of_existence", default-features = false }
 
 # These dependencies are used for the node template's RPCs
-sc-rpc-api = { default-features = false, version = "0.32.0"}
-sp-blockchain = { default-features = false, version = "27.0.0"}
-sc-basic-authorship = { default-features = false, version = "0.33.0"}
-substrate-frame-rpc-system = { default-features = false, version = "27.0.0"}
+sc-rpc-api = { version = "0.32.0"}
+sp-blockchain = { version = "27.0.0"}
+sc-basic-authorship = { version = "0.33.0"}
+substrate-frame-rpc-system = { version = "27.0.0"}
 frame-election-provider-support = { version = "27.0.0", default-features = false }
-pallet-election-provider-multi-phase = { version = "26.0.0", default-features = false }
-pallet-transaction-payment-rpc = { default-features = false, version = "29.0.0"}
-frame-benchmarking-cli = { default-features = false, version = "31.0.0"}
+pallet-transaction-payment-rpc = { version = "29.0.0"}
+frame-benchmarking-cli = { version = "31.0.0"}
 nh-runtime = { path = "runtime", version = "0.1.0" }
 
 # CLI-specific dependencies
@@ -62,10 +61,11 @@ try-runtime-cli = { version = "0.37.0" }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
 
+pallet-offences = { default-features = false, version = "26.0.0" }
+pallet-im-online = { default-features = false, version = "26.0.0" }
 pallet-authorship = { default-features = false, version = "27.0.0" }
 pallet-session = { default-features = false, version = "27.0.0" }
 pallet-staking = { default-features = false, version = "27.0.0" }
-pallet-staking-reward-curve = { default-features = false, version = "11.0.0" }
 pallet-aura = { default-features = false, version = "26.0.0" }
 pallet-balances = { default-features = false, version = "27.0.0" }
 frame-support = { default-features = false, version = "27.0.0" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -43,6 +43,7 @@ sp-keyring = { workspace = true}
 frame-system = { workspace = true}
 pallet-transaction-payment = { workspace = true, default-features = false }
 sp-staking = { workspace = true}
+pallet-im-online = { workspace = true, default-features = false }
 
 # These dependencies are used for the node template's RPCs
 jsonrpsee = { workspace = true, features = ["server"] }

--- a/node/src/benchmarking.rs
+++ b/node/src/benchmarking.rs
@@ -5,7 +5,7 @@
 use crate::service::FullClient;
 
 use nh_runtime as runtime;
-use runtime::{AccountId, Balance, BalancesCall, SystemCall};
+use runtime::{currency::Balance, AccountId, BalancesCall, SystemCall};
 use sc_cli::Result;
 use sc_client_api::BlockBackend;
 use sp_core::{Encode, Pair};

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,4 +1,5 @@
-use nh_runtime::{AccountId, SessionKeys, RuntimeGenesisConfig, Signature, WASM_BINARY};
+use nh_runtime::{AccountId, RuntimeGenesisConfig, SessionKeys, Signature, WASM_BINARY};
+use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use sc_service::{ChainType, Properties};
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
@@ -28,13 +29,22 @@ where
     AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }
 
-fn session_keys(aura: AuraId, grandpa: GrandpaId) -> SessionKeys {
-    SessionKeys{ aura, grandpa }
+fn session_keys(aura: AuraId, grandpa: GrandpaId, im_online: ImOnlineId) -> SessionKeys {
+    SessionKeys {
+        aura,
+        grandpa,
+        im_online,
+    }
 }
 
 /// Generate an Aura authority key.
-pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId, AccountId) {
-    (get_from_seed::<AuraId>(s), get_from_seed::<GrandpaId>(s), get_account_id_from_seed::<sr25519::Public>(s))
+pub fn authority_keys_from_seed(s: &str) -> (AccountId, AuraId, GrandpaId, ImOnlineId) {
+    (
+        get_account_id_from_seed::<sr25519::Public>(s),
+        get_from_seed::<AuraId>(s),
+        get_from_seed::<GrandpaId>(s),
+        get_from_seed::<ImOnlineId>(s),
+    )
 }
 
 pub fn development_config() -> Result<ChainSpec, String> {
@@ -110,11 +120,12 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
     .build())
 }
 
-const STASH: u128 = 1000;
+const INIT_BALANCE: u128 = 1u128 << 60;
+const INIT_STASH: u128 = 1u128 << 59; // Use half the balance as stake
 
 /// Configure initial storage state for FRAME modules.
 fn testnet_genesis(
-    initial_authorities: Vec<(AuraId, GrandpaId, AccountId)>,
+    initial_authorities: Vec<(AccountId, AuraId, GrandpaId, ImOnlineId)>,
     root_key: AccountId,
     endowed_accounts: Vec<AccountId>,
     _enable_println: bool,
@@ -122,22 +133,16 @@ fn testnet_genesis(
     serde_json::json!({
         "balances": {
             // Configure endowed accounts with initial balance of 1 << 60.
-            "balances": endowed_accounts.iter().cloned().map(|k| (k, 1u64 << 60)).collect::<Vec<_>>(),
+            "balances": endowed_accounts.iter().cloned().map(|k| (k, INIT_BALANCE)).collect::<Vec<_>>(),
         },
         "session": {
-            "keys": initial_authorities.iter().map(|x| { (x.2.clone(), x.2.clone(), session_keys(x.0.clone(), x.1.clone())) }).collect::<Vec<_>>(),
+            "keys": initial_authorities.iter().map(|x| { (x.0.clone(), x.0.clone(), session_keys(x.1.clone(), x.2.clone(), x.3.clone())) }).collect::<Vec<_>>(),
         },
         "staking": {
             "minimumValidatorCount": 2,
             "validatorCount": 3,
-            "stakers": initial_authorities.iter().map(|x| (x.0.clone(), x.0.clone(), STASH, sp_staking::StakerStatus::Validator::<AccountId>)).collect::<Vec<_>>(),
+            "stakers": initial_authorities.iter().map(|x| (x.1.clone(), x.1.clone(), INIT_STASH, sp_staking::StakerStatus::Validator::<AccountId>)).collect::<Vec<_>>(),
         },
-        //"aura": {
-        //    "authorities": initial_authorities.iter().map(|x| (x.0.clone())).collect::<Vec<_>>(),
-        //},
-        //"grandpa": {
-        //    "authorities": initial_authorities.iter().map(|x| (x.1.clone(), 1)).collect::<Vec<_>>(),
-        //},
         "sudo": {
             // Assign network admin rights.
             "key": Some(root_key),
@@ -156,23 +161,23 @@ mod tests {
     // The following test verifies whether we added aura configuration in the genesis block
     // by checking that the json returned by testnet_genesis() contains the field "aura"
     #[test]
-    fn testnet_genesis_should_set_aura_authorities() {
+    fn testnet_genesis_should_set_session_keys() {
         let initial_authorities = vec![authority_keys_from_seed("Alice")];
         let root_key = get_account_id_from_seed::<sr25519::Public>("Alice");
 
         let ret_val: serde_json::Value =
             testnet_genesis(initial_authorities, root_key, vec![], false);
 
-        let aura_config = &ret_val["aura"];
+        let session_config = &ret_val["session"];
 
         // Check that we have the field "aura" in the genesis config
-        assert!(!aura_config.is_null());
+        assert!(!session_config.is_null());
 
-        let auth_len = aura_config
+        let auth_len = session_config
             .as_object()
-            .map(|inner| inner["authorities"].as_array().unwrap().len())
+            .map(|inner| inner["keys"].as_array().unwrap().len())
             .unwrap();
-        // Check that we have one "authorities" set
+        // Check that we have one "keys" set
         assert_eq!(1, auth_len);
     }
 }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -8,7 +8,7 @@
 use std::sync::Arc;
 
 use jsonrpsee::RpcModule;
-use nh_runtime::{opaque::Block, AccountId, Balance, Nonce};
+use nh_runtime::{currency::Balance, opaque::Block, AccountId, Nonce};
 use sc_transaction_pool_api::TransactionPool;
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -15,10 +15,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { workspace = true, default-features = false, features = ["derive"] }
 scale-info = { workspace = true, default-features = false, features = ["derive", "serde"] }
 
+pallet-offences = { workspace = true, default-features = false }
+pallet-im-online = { workspace = true, default-features = false }
 pallet-authorship = { workspace = true, default-features = false }
 pallet-session = { workspace = true, default-features = false }
 pallet-staking = { workspace = true, default-features = false }
-pallet-staking-reward-curve = { workspace = true, default-features = false }
 pallet-aura = { workspace = true, default-features = false }
 pallet-balances = { workspace = true, default-features = false }
 frame-support = { workspace = true, default-features = false }
@@ -51,7 +52,6 @@ log = "0.4.20"
 # Used for the node template's RPCs
 frame-system-rpc-runtime-api = { workspace = true, default-features = false }
 frame-election-provider-support = { workspace = true, default-features = false }
-pallet-election-provider-multi-phase = { workspace = true, default-features = false }
 pallet-transaction-payment-rpc-runtime-api = { workspace = true, default-features = false }
 
 # Used for runtime benchmarking
@@ -79,7 +79,9 @@ std = [
 	"frame-system/std",
 	"frame-try-runtime?/std",
 	"frame-election-provider-support/std",
-	"pallet-election-provider-multi-phase/std",
+	"pallet-offences/std",
+	"pallet-im-online/std",
+	"pallet-authorship/std",
 	"pallet-aura/std",
 	"pallet-session/std",
 	"pallet-staking/std",


### PR DESCRIPTION
This PR adds proof-of-stake to the chain.

Authorities are elected according to their staked funds and nominations, for Aura authoring and Grandpa finalization.
Rewards for authoring are added, as well as slashing for active validators found offline in their authoring eras.
Grandpa offences are not tracked yet, so they do not incur any slashing.

Treasury has not been integrated yet, so that reward funds are minted from the void when needed, and slashed funds are burned.

All the new parameters, such as session/era duration and rewards, need further tuning. For now, they should represent some sensible defaults for a testnet.