### PR TITLE
Fix benchmark compilation

### DIFF
--- a/pallets/proof_of_existence/src/benchmarking.rs
+++ b/pallets/proof_of_existence/src/benchmarking.rs
@@ -15,4 +15,6 @@ benchmarks! {
     }: _(RawOrigin::Root)
 }
 
+#[cfg(test)]
+use crate::Pallet as Poe;
 impl_benchmark_test_suite!(Poe, crate::mock::new_test_ext(), crate::mock::Test,);


### PR DESCRIPTION
On my vscode I have all-features flag enable and I noted that benchmarking module have some compile errors.