### PR TITLE
Update polkadot 1.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,20 +200,6 @@ dependencies = [
 
 [[package]]
 name = "aquamarine"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da02abba9f9063d786eab1509833ebb2fac0f966862ca59439c76b9c566760"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "aquamarine"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21cc1548309245035eb18aa7f0967da6bc65587005170c56e6ef2788a4cf3f4e"
@@ -481,8 +467,24 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
 dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
+ "asn1-rs-derive 0.4.0",
+ "asn1-rs-impl 0.1.0",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive 0.5.1",
+ "asn1-rs-impl 0.2.0",
  "displaydoc",
  "nom",
  "num-traits",
@@ -500,7 +502,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -512,6 +526,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -592,6 +617,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "attohttpc"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
+dependencies = [
+ "http 0.2.12",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -1194,9 +1236,22 @@ checksum = "b9b68e3193982cd54187d71afdb2a271ad4cf8af157858e9cb911b91321de143"
 dependencies = [
  "core2",
  "multibase",
- "multihash",
+ "multihash 0.17.0",
  "serde",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
+]
+
+[[package]]
+name = "cid"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
+dependencies = [
+ "core2",
+ "multibase",
+ "multihash 0.18.1",
+ "serde",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -1301,6 +1356,16 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "comfy-table"
@@ -1531,6 +1596,21 @@ dependencies = [
  "wasmparser",
  "wasmtime-types",
 ]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -1878,7 +1958,21 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.5.2",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs 0.6.2",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -2159,6 +2253,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-zebra"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "ed25519",
+ "hashbrown 0.14.5",
+ "hex",
+ "rand_core 0.6.4",
+ "sha2 0.10.8",
+ "zeroize",
+]
+
+[[package]]
 name = "educe"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,6 +2348,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2534,6 +2655,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "fork-tree"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,6 +2688,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
 name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2559,12 +2705,12 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frame-benchmarking"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6f8e21cbac73688175cf9b531ed1c3f6578420a0f6106282aa8e5ed6fe3347"
+checksum = "48554572bd164ee905a6ff3378e46c2101610fd2ffe3110875a6503a240fb3d7"
 dependencies = [
- "frame-support",
- "frame-support-procedural",
+ "frame-support 37.0.1",
+ "frame-support-procedural 30.0.4",
  "frame-system",
  "linregress",
  "log",
@@ -2572,22 +2718,21 @@ dependencies = [
  "paste",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-runtime-interface",
- "sp-std",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
+ "sp-runtime-interface 28.0.0",
  "sp-storage",
  "static_assertions",
 ]
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "36.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be33471ac5fa10ca585d3e06642cc8c754ecd9cb8a76905bf648cff17990e32"
+checksum = "fa62cef9f98e81ae37ab965604bdc2ed5e67be6d4e05b04bc5782494b890e5b1"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -2595,38 +2740,40 @@ dependencies = [
  "clap",
  "comfy-table",
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "gethostname",
  "handlebars",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "linked-hash-map",
  "log",
  "parity-scale-codec",
  "rand 0.8.5",
  "rand_pcg",
- "sc-block-builder",
- "sc-cli",
- "sc-client-api",
- "sc-client-db",
- "sc-executor",
- "sc-service",
- "sc-sysinfo",
+ "sc-block-builder 0.42.0",
+ "sc-chain-spec 37.0.0",
+ "sc-cli 0.46.0",
+ "sc-client-api 37.0.0",
+ "sc-client-db 0.44.1",
+ "sc-executor 0.40.1",
+ "sc-service 0.45.0",
+ "sc-sysinfo 37.0.0",
  "serde",
  "serde_json",
- "sp-api",
- "sp-blockchain",
- "sp-core",
+ "sp-api 34.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
  "sp-database",
- "sp-externalities",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
+ "sp-externalities 0.29.0",
+ "sp-genesis-builder 0.15.1",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.2",
+ "sp-state-machine 0.43.0",
  "sp-storage",
- "sp-trie",
+ "sp-trie 37.0.0",
  "sp-wasm-interface",
  "thiserror",
  "thousands",
@@ -2634,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-solution-type"
-version = "13.0.0"
+version = "14.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c3bff645e46577c69c272733c53fa3a77d1ee6e40dfb66157bc94b0740b8fc"
+checksum = "8156f209055d352994ecd49e19658c6b469d7c6de923bd79868957d0dcfb6f71"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -2646,39 +2793,37 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-support"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c897b912f222280123eedee768b172ed74600292dfbb22843c95c9177e97358"
+checksum = "772f6843543fea5d5083f8f7fe714632f6ab7a230a0a805ccc669e97330494a2"
 dependencies = [
  "frame-election-provider-solution-type",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
- "sp-core",
+ "sp-core 34.0.0",
  "sp-npos-elections",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
 name = "frame-executive"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cbd97de3a8af65a9e1752b465fc19c7fe19c62ca1842ccec47f3002667c2172"
+checksum = "4dfc9b1cdc305826ef1196675a53ef7f2db8967a6cf5632775119c41d6f4e299"
 dependencies = [
- "aquamarine 0.3.3",
- "frame-support",
+ "aquamarine",
+ "frame-support 37.0.1",
  "frame-system",
- "frame-try-runtime",
+ "frame-try-runtime 0.43.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
  "sp-tracing",
 ]
 
@@ -2702,15 +2847,15 @@ checksum = "8f4afeb0769c0ef010c0dcc681a60167692a1cd52f0c0729b327a4415facddc5"
 dependencies = [
  "futures",
  "indicatif",
- "jsonrpsee",
+ "jsonrpsee 0.22.5",
  "log",
  "parity-scale-codec",
  "serde",
- "sp-core",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
  "spinners",
  "substrate-rpc-client",
  "tokio",
@@ -2723,13 +2868,13 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97100a956a2cd152ad4e63a5ec7b5e58503653223a73fff6e916b910b37f12ed"
 dependencies = [
- "aquamarine 0.5.0",
+ "aquamarine",
  "array-bytes 6.2.3",
  "bitflags 1.3.2",
  "docify",
  "environmental",
  "frame-metadata",
- "frame-support-procedural",
+ "frame-support-procedural 27.0.0",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -2740,18 +2885,60 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-api",
+ "sp-api 30.0.0",
  "sp-arithmetic",
- "sp-core",
+ "sp-core 32.0.0",
  "sp-crypto-hashing-proc-macro",
  "sp-debug-derive",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-genesis-builder 0.11.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
  "sp-metadata-ir",
- "sp-runtime",
- "sp-staking",
- "sp-state-machine",
+ "sp-runtime 35.0.0",
+ "sp-staking 30.0.0",
+ "sp-state-machine 0.39.0",
+ "sp-std",
+ "sp-tracing",
+ "sp-weights",
+ "static_assertions",
+ "tt-call",
+]
+
+[[package]]
+name = "frame-support"
+version = "37.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847939177e3637c1ec2f78eecf0755910763b8d6c3dfc04aea2efec33823b3af"
+dependencies = [
+ "aquamarine",
+ "array-bytes 6.2.3",
+ "bitflags 1.3.2",
+ "docify",
+ "environmental",
+ "frame-metadata",
+ "frame-support-procedural 30.0.4",
+ "impl-trait-for-tuples",
+ "k256",
+ "log",
+ "macro_magic",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "sp-api 34.0.0",
+ "sp-arithmetic",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing-proc-macro",
+ "sp-debug-derive",
+ "sp-genesis-builder 0.15.1",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
+ "sp-metadata-ir",
+ "sp-runtime 39.0.2",
+ "sp-staking 34.0.0",
+ "sp-state-machine 0.43.0",
  "sp-std",
  "sp-tracing",
  "sp-weights",
@@ -2769,10 +2956,30 @@ dependencies = [
  "cfg-expr",
  "derive-syn-parse",
  "expander",
- "frame-support-procedural-tools",
+ "frame-support-procedural-tools 11.0.1",
  "itertools 0.10.5",
  "macro_magic",
- "proc-macro-warning",
+ "proc-macro-warning 1.0.2",
+ "proc-macro2",
+ "quote",
+ "sp-crypto-hashing",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "frame-support-procedural"
+version = "30.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e8f9b6bc1517a6fcbf0b2377e5c8c6d39f5bb7862b191a59a9992081d63972d"
+dependencies = [
+ "Inflector",
+ "cfg-expr",
+ "derive-syn-parse",
+ "expander",
+ "frame-support-procedural-tools 13.0.0",
+ "itertools 0.11.0",
+ "macro_magic",
+ "proc-macro-warning 1.0.2",
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
@@ -2784,6 +2991,19 @@ name = "frame-support-procedural-tools"
 version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b482a1d18fa63aed1ff3fe3fcfb3bc23d92cb3903d6b9774f75dc2c4e1001c3a"
+dependencies = [
+ "frame-support-procedural-tools-derive",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "frame-support-procedural-tools"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bead15a320be1764cdd50458c4cfacb23e0cee65f64f500f8e34136a94c7eeca"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -2805,49 +3025,49 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "32.0.0"
+version = "37.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562e02f5139f1beb0edd3cac2db3f974d98b7459342210d101f451d26886ca33"
+checksum = "043790fff021477061b207fd6b33743793b63fc64a583358956787229d039717"
 dependencies = [
  "cfg-if 1.0.0",
  "docify",
- "frame-support",
+ "frame-support 37.0.1",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
  "sp-std",
- "sp-version",
+ "sp-version 37.0.0",
  "sp-weights",
 ]
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4976a4dfad8b4abff9dfc5e1a5bcdfa0452765f5c726805499ea30be0df4eaa4"
+checksum = "10fb34e948ce86f8e2ceb04d25a0edaa26e308150b6b7c8ce0cbb0e4cd814131"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
- "sp-std",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "30.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24451c0fef0c35c50bf577aadd16bb3c7b9eb74f12bb1708114d24c6f750e165"
+checksum = "475c4f8604ba7e4f05cd2c881ba71105093e638b9591ec71a8db14a64b3b4ec3"
 dependencies = [
+ "docify",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 34.0.0",
 ]
 
 [[package]]
@@ -2856,11 +3076,23 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "883f2a531ab7857e8b4bb09997f1333635da1b5e627ac1651c16b5e5152d8fa3"
 dependencies = [
- "frame-support",
+ "frame-support 32.0.0",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
+ "sp-api 30.0.0",
+ "sp-runtime 35.0.0",
  "sp-std",
+]
+
+[[package]]
+name = "frame-try-runtime"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec60be1ddc39bd312496e58b2dd82e5f3d1e0609b69f9586ba6967a36453e495"
+dependencies = [
+ "frame-support 37.0.1",
+ "parity-scale-codec",
+ "sp-api 34.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -2906,6 +3138,16 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-bounded"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b07bbbe7d7e78809544c6f718d875627addc73a7c3582447abc052cd3dc67e0"
+dependencies = [
+ "futures-timer",
  "futures-util",
 ]
 
@@ -2973,6 +3215,16 @@ dependencies = [
  "futures-io",
  "rustls 0.20.9",
  "webpki",
+]
+
+[[package]]
+name = "futures-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd3cf68c183738046838e300353e4716c674dc5e56890de4826801a6622a28"
+dependencies = [
+ "futures-io",
+ "rustls 0.21.12",
 ]
 
 [[package]]
@@ -3167,7 +3419,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.3.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.3.0",
  "slab",
  "tokio",
@@ -3388,14 +3659,14 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-std",
- "frame-support",
+ "frame-support 37.0.1",
  "hex-literal",
  "hp-verifiers",
  "parity-scale-codec",
  "rstest",
  "rstest_reuse",
  "scale-info",
- "sp-runtime-interface",
+ "sp-runtime-interface 28.0.0",
  "sp-std",
 ]
 
@@ -3407,9 +3678,9 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "snafu 0.8.4",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -3418,8 +3689,8 @@ version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
  "sp-std",
  "sp-weights",
 ]
@@ -3436,13 +3707,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite 0.2.14",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite 0.2.14",
 ]
 
@@ -3480,9 +3785,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -3495,19 +3800,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite 0.2.14",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.30",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.5.0",
+ "pin-project-lite 0.2.14",
+ "tokio",
+ "tower",
+ "tower-service",
 ]
 
 [[package]]
@@ -3552,6 +3894,16 @@ dependencies = [
 
 [[package]]
 name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
@@ -3587,6 +3939,25 @@ dependencies = [
  "system-configuration",
  "tokio",
  "windows",
+]
+
+[[package]]
+name = "igd-next"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
+dependencies = [
+ "async-trait",
+ "attohttpc",
+ "bytes",
+ "futures",
+ "http 0.2.12",
+ "hyper 0.14.30",
+ "log",
+ "rand 0.8.5",
+ "tokio",
+ "url",
+ "xmltree",
 ]
 
 [[package]]
@@ -3762,6 +4133,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -3808,12 +4188,26 @@ version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdb12a2381ea5b2e68c3469ec604a007b367778cdb14d09612c8069ebd616ad"
 dependencies = [
- "jsonrpsee-core",
+ "jsonrpsee-core 0.22.5",
  "jsonrpsee-http-client",
- "jsonrpsee-proc-macros",
- "jsonrpsee-server",
- "jsonrpsee-types",
+ "jsonrpsee-proc-macros 0.22.5",
+ "jsonrpsee-server 0.22.5",
+ "jsonrpsee-types 0.22.5",
  "jsonrpsee-ws-client",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b089779ad7f80768693755a031cc14a7766aba707cbe886674e3f79e9b7e47"
+dependencies = [
+ "jsonrpsee-core 0.23.2",
+ "jsonrpsee-proc-macros 0.23.2",
+ "jsonrpsee-server 0.23.2",
+ "jsonrpsee-types 0.23.2",
  "tokio",
  "tracing",
 ]
@@ -3825,12 +4219,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4978087a58c3ab02efc5b07c5e5e2803024536106fd5506f558db172c889b3aa"
 dependencies = [
  "futures-util",
- "http",
- "jsonrpsee-core",
+ "http 0.2.12",
+ "jsonrpsee-core 0.22.5",
  "pin-project",
  "rustls-native-certs 0.7.1",
  "rustls-pki-types",
- "soketto",
+ "soketto 0.7.1",
  "thiserror",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -3850,8 +4244,8 @@ dependencies = [
  "beef",
  "futures-timer",
  "futures-util",
- "hyper",
- "jsonrpsee-types",
+ "hyper 0.14.30",
+ "jsonrpsee-types 0.22.5",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
@@ -3865,16 +4259,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-core"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79712302e737d23ca0daa178e752c9334846b08321d439fd89af9a384f8c830b"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "beef",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "jsonrpsee-types 0.23.2",
+ "parking_lot 0.12.3",
+ "rand 0.8.5",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "jsonrpsee-http-client"
 version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ccf93fc4a0bfe05d851d37d7c32b7f370fe94336b52a2f0efc5f1981895c2e5"
 dependencies = [
  "async-trait",
- "hyper",
+ "hyper 0.14.30",
  "hyper-rustls",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.22.5",
+ "jsonrpsee-types 0.22.5",
  "serde",
  "serde_json",
  "thiserror",
@@ -3898,21 +4317,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7895f186d5921065d96e16bd795e5ca89ac8356ec423fafc6e3d7cf8ec11aee4"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "jsonrpsee-server"
 version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12d8b6a9674422a8572e0b0abb12feeb3f2aeda86528c80d0350c2bd0923ab41"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "http 0.2.12",
+ "hyper 0.14.30",
+ "jsonrpsee-core 0.22.5",
+ "jsonrpsee-types 0.22.5",
  "pin-project",
  "route-recognizer",
  "serde",
  "serde_json",
- "soketto",
+ "soketto 0.7.1",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-server"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654afab2e92e5d88ebd8a39d6074483f3f2bfdf91c5ac57fe285e7127cdd4f51"
+dependencies = [
+ "anyhow",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.0",
+ "hyper-util",
+ "jsonrpsee-core 0.23.2",
+ "jsonrpsee-types 0.23.2",
+ "pin-project",
+ "route-recognizer",
+ "serde",
+ "serde_json",
+ "soketto 0.8.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3935,15 +4395,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-types"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c465fbe385238e861fdc4d1c85e04ada6c1fd246161d26385c1b311724d2af"
+dependencies = [
+ "beef",
+ "http 1.1.0",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "jsonrpsee-ws-client"
 version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58b9db2dfd5bb1194b0ce921504df9ceae210a345bc2f6c5a61432089bbab070"
 dependencies = [
- "http",
+ "http 0.2.12",
  "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.22.5",
+ "jsonrpsee-types 0.22.5",
  "url",
 ]
 
@@ -4089,26 +4562,63 @@ dependencies = [
  "futures-timer",
  "getrandom 0.2.15",
  "instant",
- "libp2p-allow-block-list",
- "libp2p-connection-limits",
- "libp2p-core",
- "libp2p-dns",
- "libp2p-identify",
- "libp2p-identity",
- "libp2p-kad",
- "libp2p-mdns",
- "libp2p-metrics",
- "libp2p-noise",
- "libp2p-ping",
- "libp2p-quic",
- "libp2p-request-response",
- "libp2p-swarm",
- "libp2p-tcp",
- "libp2p-wasm-ext",
- "libp2p-websocket",
- "libp2p-yamux",
- "multiaddr",
+ "libp2p-allow-block-list 0.1.1",
+ "libp2p-connection-limits 0.1.0",
+ "libp2p-core 0.39.2",
+ "libp2p-dns 0.39.0",
+ "libp2p-identify 0.42.2",
+ "libp2p-identity 0.1.3",
+ "libp2p-kad 0.43.3",
+ "libp2p-mdns 0.43.1",
+ "libp2p-metrics 0.12.0",
+ "libp2p-noise 0.42.2",
+ "libp2p-ping 0.42.0",
+ "libp2p-quic 0.7.0-alpha.3",
+ "libp2p-request-response 0.24.1",
+ "libp2p-swarm 0.42.2",
+ "libp2p-tcp 0.39.0",
+ "libp2p-wasm-ext 0.39.0",
+ "libp2p-websocket 0.41.0",
+ "libp2p-yamux 0.43.1",
+ "multiaddr 0.17.1",
  "pin-project",
+]
+
+[[package]]
+name = "libp2p"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94495eb319a85b70a68b85e2389a95bb3555c71c49025b78c691a854a7e6464"
+dependencies = [
+ "bytes",
+ "either",
+ "futures",
+ "futures-timer",
+ "getrandom 0.2.15",
+ "instant",
+ "libp2p-allow-block-list 0.2.0",
+ "libp2p-connection-limits 0.2.1",
+ "libp2p-core 0.40.1",
+ "libp2p-dns 0.40.1",
+ "libp2p-identify 0.43.1",
+ "libp2p-identity 0.2.9",
+ "libp2p-kad 0.44.6",
+ "libp2p-mdns 0.44.0",
+ "libp2p-metrics 0.13.1",
+ "libp2p-noise 0.43.2",
+ "libp2p-ping 0.43.1",
+ "libp2p-quic 0.9.3",
+ "libp2p-request-response 0.25.3",
+ "libp2p-swarm 0.43.7",
+ "libp2p-tcp 0.40.1",
+ "libp2p-upnp",
+ "libp2p-wasm-ext 0.40.0",
+ "libp2p-websocket 0.42.2",
+ "libp2p-yamux 0.44.1",
+ "multiaddr 0.18.2",
+ "pin-project",
+ "rw-stream-sink 0.4.0",
+ "thiserror",
 ]
 
 [[package]]
@@ -4117,9 +4627,21 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "510daa05efbc25184458db837f6f9a5143888f1caa742426d92e1833ddd38a50"
 dependencies = [
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.3",
+ "libp2p-swarm 0.42.2",
+ "void",
+]
+
+[[package]]
+name = "libp2p-allow-block-list"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b46558c5c0bf99d3e2a1a38fd54ff5476ca66dd1737b12466a1824dd219311"
+dependencies = [
+ "libp2p-core 0.40.1",
+ "libp2p-identity 0.2.9",
+ "libp2p-swarm 0.43.7",
  "void",
 ]
 
@@ -4129,9 +4651,21 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4caa33f1d26ed664c4fe2cca81a08c8e07d4c1c04f2f4ac7655c2dd85467fda0"
 dependencies = [
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.3",
+ "libp2p-swarm 0.42.2",
+ "void",
+]
+
+[[package]]
+name = "libp2p-connection-limits"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f5107ad45cb20b2f6c3628c7b6014b996fcb13a88053f4569c872c6e30abf58"
+dependencies = [
+ "libp2p-core 0.40.1",
+ "libp2p-identity 0.2.9",
+ "libp2p-swarm 0.43.7",
  "void",
 ]
 
@@ -4146,20 +4680,48 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "log",
- "multiaddr",
- "multihash",
- "multistream-select",
+ "multiaddr 0.17.1",
+ "multihash 0.17.0",
+ "multistream-select 0.12.1",
  "once_cell",
  "parking_lot 0.12.3",
  "pin-project",
  "quick-protobuf",
  "rand 0.8.5",
- "rw-stream-sink",
+ "rw-stream-sink 0.3.0",
  "smallvec",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
+ "void",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd44289ab25e4c9230d9246c475a22241e301b23e8f4061d3bdef304a1a99713"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-identity 0.2.9",
+ "log",
+ "multiaddr 0.18.2",
+ "multihash 0.19.1",
+ "multistream-select 0.13.0",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "quick-protobuf",
+ "rand 0.8.5",
+ "rw-stream-sink 0.4.0",
+ "smallvec",
+ "thiserror",
+ "unsigned-varint 0.7.2",
  "void",
 ]
 
@@ -4170,11 +4732,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146ff7034daae62077c415c2376b8057368042df6ab95f5432ad5e88568b1554"
 dependencies = [
  "futures",
- "libp2p-core",
+ "libp2p-core 0.39.2",
  "log",
  "parking_lot 0.12.3",
  "smallvec",
- "trust-dns-resolver",
+ "trust-dns-resolver 0.22.0",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6a18db73084b4da2871438f6239fef35190b05023de7656e877c18a00541a3b"
+dependencies = [
+ "async-trait",
+ "futures",
+ "libp2p-core 0.40.1",
+ "libp2p-identity 0.2.9",
+ "log",
+ "parking_lot 0.12.3",
+ "smallvec",
+ "trust-dns-resolver 0.23.2",
 ]
 
 [[package]]
@@ -4187,13 +4765,36 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.3",
+ "libp2p-swarm 0.42.2",
  "log",
- "lru",
+ "lru 0.10.1",
  "quick-protobuf",
- "quick-protobuf-codec",
+ "quick-protobuf-codec 0.1.0",
+ "smallvec",
+ "thiserror",
+ "void",
+]
+
+[[package]]
+name = "libp2p-identify"
+version = "0.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a96638a0a176bec0a4bcaebc1afa8cf909b114477209d7456ade52c61cd9cd"
+dependencies = [
+ "asynchronous-codec",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core 0.40.1",
+ "libp2p-identity 0.2.9",
+ "libp2p-swarm 0.43.7",
+ "log",
+ "lru 0.12.4",
+ "quick-protobuf",
+ "quick-protobuf-codec 0.2.0",
  "smallvec",
  "thiserror",
  "void",
@@ -4208,12 +4809,30 @@ dependencies = [
  "bs58 0.4.0",
  "ed25519-dalek",
  "log",
- "multiaddr",
- "multihash",
+ "multiaddr 0.17.1",
+ "multihash 0.17.0",
  "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.8",
  "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-identity"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cca1eb2bc1fd29f099f3daaab7effd01e1a54b7c577d0ed082521034d912e8"
+dependencies = [
+ "bs58 0.5.1",
+ "ed25519-dalek",
+ "hkdf",
+ "multihash 0.19.1",
+ "quick-protobuf",
+ "rand 0.8.5",
+ "sha2 0.10.8",
+ "thiserror",
+ "tracing",
  "zeroize",
 ]
 
@@ -4231,9 +4850,9 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.3",
+ "libp2p-swarm 0.42.2",
  "log",
  "quick-protobuf",
  "rand 0.8.5",
@@ -4241,7 +4860,36 @@ dependencies = [
  "smallvec",
  "thiserror",
  "uint",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
+ "void",
+]
+
+[[package]]
+name = "libp2p-kad"
+version = "0.44.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ea178dabba6dde6ffc260a8e0452ccdc8f79becf544946692fff9d412fc29d"
+dependencies = [
+ "arrayvec 0.7.4",
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core 0.40.1",
+ "libp2p-identity 0.2.9",
+ "libp2p-swarm 0.43.7",
+ "log",
+ "quick-protobuf",
+ "quick-protobuf-codec 0.2.0",
+ "rand 0.8.5",
+ "sha2 0.10.8",
+ "smallvec",
+ "thiserror",
+ "uint",
+ "unsigned-varint 0.7.2",
  "void",
 ]
 
@@ -4254,15 +4902,36 @@ dependencies = [
  "data-encoding",
  "futures",
  "if-watch",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.3",
+ "libp2p-swarm 0.42.2",
  "log",
  "rand 0.8.5",
  "smallvec",
  "socket2 0.4.10",
  "tokio",
- "trust-dns-proto",
+ "trust-dns-proto 0.22.0",
+ "void",
+]
+
+[[package]]
+name = "libp2p-mdns"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a2567c305232f5ef54185e9604579a894fd0674819402bb0ac0246da82f52a"
+dependencies = [
+ "data-encoding",
+ "futures",
+ "if-watch",
+ "libp2p-core 0.40.1",
+ "libp2p-identity 0.2.9",
+ "libp2p-swarm 0.43.7",
+ "log",
+ "rand 0.8.5",
+ "smallvec",
+ "socket2 0.5.7",
+ "tokio",
+ "trust-dns-proto 0.22.0",
  "void",
 ]
 
@@ -4272,12 +4941,29 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a42ec91e227d7d0dafa4ce88b333cdf5f277253873ab087555c92798db2ddd46"
 dependencies = [
- "libp2p-core",
- "libp2p-identify",
- "libp2p-kad",
- "libp2p-ping",
- "libp2p-swarm",
- "prometheus-client",
+ "libp2p-core 0.39.2",
+ "libp2p-identify 0.42.2",
+ "libp2p-kad 0.43.3",
+ "libp2p-ping 0.42.0",
+ "libp2p-swarm 0.42.2",
+ "prometheus-client 0.19.0",
+]
+
+[[package]]
+name = "libp2p-metrics"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239ba7d28f8d0b5d77760dc6619c05c7e88e74ec8fbbe97f856f20a56745e620"
+dependencies = [
+ "instant",
+ "libp2p-core 0.40.1",
+ "libp2p-identify 0.43.1",
+ "libp2p-identity 0.2.9",
+ "libp2p-kad 0.44.6",
+ "libp2p-ping 0.43.1",
+ "libp2p-swarm 0.43.7",
+ "once_cell",
+ "prometheus-client 0.21.2",
 ]
 
 [[package]]
@@ -4289,8 +4975,8 @@ dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
  "futures",
- "libp2p-core",
- "libp2p-identity",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.3",
  "log",
  "once_cell",
  "quick-protobuf",
@@ -4304,6 +4990,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-noise"
+version = "0.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2eeec39ad3ad0677551907dd304b2f13f17208ccebe333bef194076cd2e8921"
+dependencies = [
+ "bytes",
+ "curve25519-dalek 4.1.3",
+ "futures",
+ "libp2p-core 0.40.1",
+ "libp2p-identity 0.2.9",
+ "log",
+ "multiaddr 0.18.2",
+ "multihash 0.19.1",
+ "once_cell",
+ "quick-protobuf",
+ "rand 0.8.5",
+ "sha2 0.10.8",
+ "snow",
+ "static_assertions",
+ "thiserror",
+ "x25519-dalek 2.0.1",
+ "zeroize",
+]
+
+[[package]]
 name = "libp2p-ping"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4313,8 +5024,26 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.39.2",
+ "libp2p-swarm 0.42.2",
+ "log",
+ "rand 0.8.5",
+ "void",
+]
+
+[[package]]
+name = "libp2p-ping"
+version = "0.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e702d75cd0827dfa15f8fd92d15b9932abe38d10d21f47c50438c71dd1b5dae3"
+dependencies = [
+ "either",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core 0.40.1",
+ "libp2p-identity 0.2.9",
+ "libp2p-swarm 0.43.7",
  "log",
  "rand 0.8.5",
  "void",
@@ -4330,14 +5059,38 @@ dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-tls",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.3",
+ "libp2p-tls 0.1.0",
  "log",
  "parking_lot 0.12.3",
- "quinn-proto",
+ "quinn-proto 0.9.6",
  "rand 0.8.5",
  "rustls 0.20.9",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "libp2p-quic"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "130d451d83f21b81eb7b35b360bc7972aeafb15177784adc56528db082e6b927"
+dependencies = [
+ "bytes",
+ "futures",
+ "futures-timer",
+ "if-watch",
+ "libp2p-core 0.40.1",
+ "libp2p-identity 0.2.9",
+ "libp2p-tls 0.2.1",
+ "log",
+ "parking_lot 0.12.3",
+ "quinn 0.10.2",
+ "rand 0.8.5",
+ "ring 0.16.20",
+ "rustls 0.21.12",
+ "socket2 0.5.7",
  "thiserror",
  "tokio",
 ]
@@ -4351,11 +5104,29 @@ dependencies = [
  "async-trait",
  "futures",
  "instant",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.3",
+ "libp2p-swarm 0.42.2",
  "rand 0.8.5",
  "smallvec",
+]
+
+[[package]]
+name = "libp2p-request-response"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e3b4d67870478db72bac87bfc260ee6641d0734e0e3e275798f089c3fecfd4"
+dependencies = [
+ "async-trait",
+ "futures",
+ "instant",
+ "libp2p-core 0.40.1",
+ "libp2p-identity 0.2.9",
+ "libp2p-swarm 0.43.7",
+ "log",
+ "rand 0.8.5",
+ "smallvec",
+ "void",
 ]
 
 [[package]]
@@ -4369,10 +5140,33 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm-derive",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.3",
+ "libp2p-swarm-derive 0.32.0",
  "log",
+ "rand 0.8.5",
+ "smallvec",
+ "tokio",
+ "void",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.43.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "580189e0074af847df90e75ef54f3f30059aedda37ea5a1659e8b9fca05c0141"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core 0.40.1",
+ "libp2p-identity 0.2.9",
+ "libp2p-swarm-derive 0.33.0",
+ "log",
+ "multistream-select 0.13.0",
+ "once_cell",
  "rand 0.8.5",
  "smallvec",
  "tokio",
@@ -4391,6 +5185,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-swarm-derive"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4d5ec2a3df00c7836d7696c136274c9c59705bac69133253696a6c932cd1d74"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-warning 0.4.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "libp2p-tcp"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4400,9 +5207,26 @@ dependencies = [
  "futures-timer",
  "if-watch",
  "libc",
- "libp2p-core",
+ "libp2p-core 0.39.2",
  "log",
  "socket2 0.4.10",
+ "tokio",
+]
+
+[[package]]
+name = "libp2p-tcp"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b558dd40d1bcd1aaaed9de898e9ec6a436019ecc2420dd0016e712fbb61c5508"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "if-watch",
+ "libc",
+ "libp2p-core 0.40.1",
+ "libp2p-identity 0.2.9",
+ "log",
+ "socket2 0.5.7",
  "tokio",
 ]
 
@@ -4413,16 +5237,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff08d13d0dc66e5e9ba6279c1de417b84fa0d0adc3b03e5732928c180ec02781"
 dependencies = [
  "futures",
- "futures-rustls",
- "libp2p-core",
- "libp2p-identity",
+ "futures-rustls 0.22.2",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.3",
  "rcgen",
  "ring 0.16.20",
  "rustls 0.20.9",
  "thiserror",
  "webpki",
- "x509-parser",
+ "x509-parser 0.14.0",
  "yasna",
+]
+
+[[package]]
+name = "libp2p-tls"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8218d1d5482b122ccae396bbf38abdcb283ecc96fa54760e1dfd251f0546ac61"
+dependencies = [
+ "futures",
+ "futures-rustls 0.24.0",
+ "libp2p-core 0.40.1",
+ "libp2p-identity 0.2.9",
+ "rcgen",
+ "ring 0.16.20",
+ "rustls 0.21.12",
+ "rustls-webpki 0.101.7",
+ "thiserror",
+ "x509-parser 0.15.1",
+ "yasna",
+]
+
+[[package]]
+name = "libp2p-upnp"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82775a47b34f10f787ad3e2a22e2c1541e6ebef4fe9f28f3ac553921554c94c1"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "igd-next",
+ "libp2p-core 0.40.1",
+ "libp2p-swarm 0.43.7",
+ "log",
+ "tokio",
+ "void",
 ]
 
 [[package]]
@@ -4433,8 +5292,22 @@ checksum = "77dff9d32353a5887adb86c8afc1de1a94d9e8c3bc6df8b2201d7cdf5c848f43"
 dependencies = [
  "futures",
  "js-sys",
- "libp2p-core",
+ "libp2p-core 0.39.2",
  "parity-send-wrapper",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "libp2p-wasm-ext"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e5d8e3a9e07da0ef5b55a9f26c009c8fb3c725d492d8bb4b431715786eea79c"
+dependencies = [
+ "futures",
+ "js-sys",
+ "libp2p-core 0.40.1",
+ "send_wrapper",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -4447,15 +5320,36 @@ checksum = "111273f7b3d3510524c752e8b7a5314b7f7a1fee7e68161c01a7d72cbb06db9f"
 dependencies = [
  "either",
  "futures",
- "futures-rustls",
- "libp2p-core",
+ "futures-rustls 0.22.2",
+ "libp2p-core 0.39.2",
  "log",
  "parking_lot 0.12.3",
  "quicksink",
- "rw-stream-sink",
- "soketto",
+ "rw-stream-sink 0.3.0",
+ "soketto 0.7.1",
  "url",
- "webpki-roots",
+ "webpki-roots 0.22.6",
+]
+
+[[package]]
+name = "libp2p-websocket"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004ee9c4a4631435169aee6aad2f62e3984dc031c43b6d29731e8e82a016c538"
+dependencies = [
+ "either",
+ "futures",
+ "futures-rustls 0.24.0",
+ "libp2p-core 0.40.1",
+ "libp2p-identity 0.2.9",
+ "log",
+ "parking_lot 0.12.3",
+ "pin-project-lite 0.2.14",
+ "rw-stream-sink 0.4.0",
+ "soketto 0.8.0",
+ "thiserror",
+ "url",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -4465,10 +5359,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd21d950662700a385d4c6d68e2f5f54d778e97068cdd718522222ef513bda"
 dependencies = [
  "futures",
- "libp2p-core",
+ "libp2p-core 0.39.2",
  "log",
  "thiserror",
- "yamux",
+ "yamux 0.10.2",
+]
+
+[[package]]
+name = "libp2p-yamux"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eedcb62824c4300efb9cfd4e2a6edaf3ca097b9e68b36dabe45a44469fd6a85"
+dependencies = [
+ "futures",
+ "libp2p-core 0.40.1",
+ "log",
+ "thiserror",
+ "yamux 0.12.1",
 ]
 
 [[package]]
@@ -4613,6 +5520,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "litep2p"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f46c51c205264b834ceed95c8b195026e700494bc3991aaba3b4ea9e20626d9"
+dependencies = [
+ "async-trait",
+ "bs58 0.4.0",
+ "bytes",
+ "cid 0.10.1",
+ "ed25519-dalek",
+ "futures",
+ "futures-timer",
+ "hex-literal",
+ "indexmap 2.3.0",
+ "libc",
+ "mockall 0.12.1",
+ "multiaddr 0.17.1",
+ "multihash 0.17.0",
+ "network-interface",
+ "nohash-hasher",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "prost 0.12.6",
+ "prost-build 0.11.9",
+ "quinn 0.9.4",
+ "rand 0.8.5",
+ "rcgen",
+ "ring 0.16.20",
+ "rustls 0.20.9",
+ "serde",
+ "sha2 0.10.8",
+ "simple-dns",
+ "smallvec",
+ "snow",
+ "socket2 0.5.7",
+ "static_assertions",
+ "str0m",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tracing",
+ "trust-dns-resolver 0.23.2",
+ "uint",
+ "unsigned-varint 0.8.0",
+ "url",
+ "webpki",
+ "x25519-dalek 2.0.1",
+ "x509-parser 0.16.0",
+ "yasna",
+ "zeroize",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4635,6 +5597,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718e8fae447df0c7e1ba7f5189829e63fd536945c8988d61444c19039f16b670"
 dependencies = [
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4733,7 +5704,7 @@ dependencies = [
  "frame-system",
  "futures",
  "hp-poe",
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "native",
  "native-cache",
  "pallet-im-online",
@@ -4741,39 +5712,39 @@ dependencies = [
  "pallet-transaction-payment-rpc",
  "proof-of-existence-rpc",
  "sc-basic-authorship",
- "sc-cli",
- "sc-client-api",
- "sc-consensus",
+ "sc-cli 0.46.0",
+ "sc-client-api 37.0.0",
+ "sc-consensus 0.43.0",
  "sc-consensus-babe",
  "sc-consensus-babe-rpc",
  "sc-consensus-grandpa",
  "sc-consensus-grandpa-rpc",
- "sc-executor",
- "sc-network",
+ "sc-executor 0.40.1",
+ "sc-network 0.44.0",
  "sc-offchain",
- "sc-rpc",
- "sc-rpc-api",
- "sc-service",
- "sc-sysinfo",
- "sc-telemetry",
- "sc-transaction-pool",
- "sc-transaction-pool-api",
+ "sc-rpc 39.0.0",
+ "sc-rpc-api 0.43.0",
+ "sc-service 0.45.0",
+ "sc-sysinfo 37.0.0",
+ "sc-telemetry 24.0.0",
+ "sc-transaction-pool 37.0.0",
+ "sc-transaction-pool-api 37.0.0",
  "serde_json",
- "sp-api",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-babe",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-keyring",
- "sp-keystore",
- "sp-runtime",
- "sp-runtime-interface",
- "sp-staking",
- "sp-timestamp",
+ "sp-api 34.0.0",
+ "sp-block-builder 34.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-consensus 0.40.0",
+ "sp-consensus-babe 0.40.0",
+ "sp-consensus-grandpa 21.0.0",
+ "sp-core 34.0.0",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
+ "sp-keyring 39.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.2",
+ "sp-runtime-interface 28.0.0",
+ "sp-staking 34.0.0",
+ "sp-timestamp 34.0.0",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "try-runtime-cli",
@@ -4797,6 +5768,15 @@ name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
@@ -4940,7 +5920,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_distr",
  "subtle 2.6.1",
  "thiserror",
@@ -4957,8 +5937,23 @@ dependencies = [
  "downcast",
  "fragile",
  "lazy_static",
- "mockall_derive",
- "predicates",
+ "mockall_derive 0.11.4",
+ "predicates 2.1.5",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if 1.0.0",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive 0.12.1",
+ "predicates 3.1.2",
  "predicates-tree",
 ]
 
@@ -4975,6 +5970,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4985,11 +5992,30 @@ dependencies = [
  "data-encoding",
  "log",
  "multibase",
- "multihash",
+ "multihash 0.17.0",
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
+ "url",
+]
+
+[[package]]
+name = "multiaddr"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
+dependencies = [
+ "arrayref",
+ "byteorder",
+ "data-encoding",
+ "libp2p-identity 0.2.9",
+ "multibase",
+ "multihash 0.19.1",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.8.0",
  "url",
 ]
 
@@ -5018,7 +6044,34 @@ dependencies = [
  "multihash-derive",
  "sha2 0.10.8",
  "sha3",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
+]
+
+[[package]]
+name = "multihash"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
+dependencies = [
+ "blake2b_simd",
+ "blake2s_simd 1.0.2",
+ "blake3",
+ "core2",
+ "digest 0.10.7",
+ "multihash-derive",
+ "sha2 0.10.8",
+ "sha3",
+ "unsigned-varint 0.7.2",
+]
+
+[[package]]
+name = "multihash"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
+dependencies = [
+ "core2",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -5032,7 +6085,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -5052,7 +6105,21 @@ dependencies = [
  "log",
  "pin-project",
  "smallvec",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
+]
+
+[[package]]
+name = "multistream-select"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "pin-project",
+ "smallvec",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -5101,7 +6168,7 @@ dependencies = [
  "native-cache",
  "parity-scale-codec",
  "risc0-verifier",
- "sp-runtime-interface",
+ "sp-runtime-interface 28.0.0",
  "ultraplonk_verifier",
  "zksync-era-verifier",
  "zksync-era-verifier-deserialize",
@@ -5184,6 +6251,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "network-interface"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a43439bf756eed340bdf8feba761e2d50c7d47175d87545cd5cbe4a137c4d1"
+dependencies = [
+ "cc",
+ "libc",
+ "thiserror",
+ "winapi",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5223,6 +6302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
 name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5233,6 +6318,16 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-bigint"
@@ -5351,7 +6446,16 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.5.2",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs 0.6.2",
 ]
 
 [[package]]
@@ -5373,16 +6477,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.3.2+3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pairing_ce"
@@ -5399,27 +6557,26 @@ dependencies = [
 
 [[package]]
 name = "pallet-authorship"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3544ca79d7b1f3b9a0efe6b54038143962e8b05d57a3a4172cd11e7216c43d6"
+checksum = "6ddfa02ecfdd0bfa4841dc16ebd3bdd0d1918751b845f4b36b29c01bfaf75b5b"
 dependencies = [
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
 name = "pallet-babe"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac02d082761843190fddfea58ce3a8cf042e92d2d78bb21426d2f960880a875c"
+checksum = "cf4cee370246a2a8fa7d62b02b96febde7c8b09d18c9b8ce3a35c20a142379c8"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "log",
  "pallet-authorship",
@@ -5427,126 +6584,119 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
- "sp-consensus-babe",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-std",
+ "sp-application-crypto 38.0.0",
+ "sp-consensus-babe 0.40.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
+ "sp-session 35.0.0",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "pallet-bags-list"
-version = "31.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664e6da2fe296a6597f2508f8754bfedaf06b5fc7bc657f7327b7d91896f84f7"
+checksum = "5143d9c729fe3f02a3ff8d9800dd538717a35f2738aa35828347a060251f41ca"
 dependencies = [
- "aquamarine 0.5.0",
+ "aquamarine",
  "docify",
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
  "sp-tracing",
 ]
 
 [[package]]
 name = "pallet-balances"
-version = "33.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b56b559fbf1b04e08f42b08c0cb133cf732b4b0cafd315a3a24ba1ae60669d7e"
+checksum = "267f2b4c64e06d340fab1e48267e815dc2afaf8e6da16369b26b5c9e1e65f1aa"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
 name = "pallet-bounties"
-version = "31.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe92916d8bb2f2ce84195ae5e6baec83c5a65bf685613d7cc207f0b8fd26ea43"
+checksum = "5b025a04d02a33335672b144d58a824ca25c45848867180dbc416618f43d3408"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
 name = "pallet-child-bounties"
-version = "31.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5612487abb09a9e5b6f3a694639fd0826a8b3bae1335047899f032f292f7f410"
+checksum = "6ac635059b34dc038781c6d8892aa90327ec2491d4afdcace97e6d66e5ca9da3"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "log",
  "pallet-bounties",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43080685819927c77fb38dda17e593eab2478406d674dd8c69200129cf613e77"
+checksum = "755ac1497eb1b7509f501fabe1f6d8694b8e316aa10c3987f470a2fdeb4e597f"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "31.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d47f77fc73b1caf6317515e884a1451786c8b71fddd910b753a73da7ee4fe84"
+checksum = "cd65dad4b4de7ec4b0d1631d1e8ad8766eaaa0ab4e871ec6c73a1e894c68afc9"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-system",
  "parity-scale-codec",
  "sp-npos-elections",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -5555,7 +6705,7 @@ version = "0.1.0"
 dependencies = [
  "fflonk_verifier",
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "hex-literal",
  "hp-verifiers",
@@ -5564,34 +6714,33 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
  "substrate-bn",
 ]
 
 [[package]]
 name = "pallet-grandpa"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6beb51686baee78fc838861b825c1b8f1b66a7633dc502dc70da491aed82dcbb"
+checksum = "78a9db737c0ad83212dd874658194b1be7d9cb3c093599aa02573645f9b991f4"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-std",
+ "sp-application-crypto 38.0.0",
+ "sp-consensus-grandpa 21.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
+ "sp-session 35.0.0",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
@@ -5599,7 +6748,7 @@ name = "pallet-groth16-verifier"
 version = "0.2.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "hex-literal",
  "hp-groth16",
@@ -5610,66 +6759,63 @@ dependencies = [
  "rstest",
  "rstest_reuse",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-im-online"
-version = "31.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c771c379dfa58623a6d88d021c7cebe1f9f4f4537155917f7a9c03b5b36c3ec"
+checksum = "be560a30bb7b6e829c9827edb10d1e30facbc923d4fd9ee86476e82eecdda27d"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "log",
  "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
- "sp-std",
+ "sp-application-crypto 38.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "pallet-multisig"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b3d75a9319f7bcb58920ecc087aa246cc4cac0bcf5c9f29bb44260315961db"
+checksum = "b836d56979a4cd33b68bca09ea34bd0eb524fad8711cb6471ec84a5c3318ea6f"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
 name = "pallet-offences"
-version = "31.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "621a7fe9a24a3f69cbb14b06c94894b81ad0aa549dbfff178c9236876cf5a892"
+checksum = "7b364e0756f83bcdfd69fd3255a8088f9f048223850f7b86a42742c2e667c694"
 dependencies = [
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime",
- "sp-staking",
- "sp-std",
+ "sp-runtime 39.0.2",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
@@ -5678,7 +6824,7 @@ version = "0.1.0"
 dependencies = [
  "binary-merkle-tree",
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "hex-literal",
  "hp-poe",
@@ -5686,28 +6832,27 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-preimage"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28de923b335df5fc38c9e0b565230120184f5e195624a386cd9bec90fda4b55"
+checksum = "f1d77b400c54d7d6645a768a62a430dba851e553d9eef9376cfa1ab0e13acf13"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -5716,7 +6861,7 @@ version = "0.1.0"
 dependencies = [
  "educe",
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "hex-literal",
  "hp-verifiers",
@@ -5726,45 +6871,43 @@ dependencies = [
  "proof-of-sql-verifier",
  "rstest",
  "scale-info",
- "sp-core",
- "sp-io",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-proxy"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936d02c265142821c0144336d6724ec1fc56ddf333837f5ab502798fab5a447e"
+checksum = "728a6f11efebb88d9c64fa3335fb376d3603302ee46bbbe36fff8e1d0e01d0d4"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
 name = "pallet-referenda"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf5abb788c5e8e7960820288caa043f5d037a63248453d493e617a2445790a4"
+checksum = "77142a71cbc241ebc5ec11d65868379b7d5440e07ae7545f1bfd5933485f1a13"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -5772,106 +6915,102 @@ name = "pallet-risc0-verifier"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "hex-literal",
  "hp-verifiers",
  "log",
  "native",
  "pallet-verifiers",
- "sp-core",
+ "sp-core 34.0.0",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-scheduler"
-version = "33.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fac215d9cf301396720219c4d04e4fe7fcf44d14d4be71f9c3ae3df3cead74"
+checksum = "ca20e5a34daccd584fa00e2239113cbb7e6097d03064a8e7dc4df0640ac8dfce"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-session"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061827f23d4a702a2e159ff84286a0a89488615c31ad05a9af7cc93a57e2b441"
+checksum = "84da59cf6db5db9a4424a5967787bf4ea20bfa903988a2438429c09a48365acf"
 dependencies = [
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-state-machine",
- "sp-std",
- "sp-trie",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
+ "sp-session 35.0.0",
+ "sp-staking 34.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817dd673f7d0b965639d27def260f7ff7a1535f2c5016a611445a8e4dedcf5cd"
+checksum = "018aab2ea95d8aacd1d6e7aab408a0bef45087269b00646a74efac859952175e"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
  "rand 0.8.5",
- "sp-runtime",
- "sp-session",
- "sp-std",
+ "sp-runtime 39.0.2",
+ "sp-session 35.0.0",
 ]
 
 [[package]]
 name = "pallet-staking"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8ab61dc6b74c79ad396732c1850dafa89109b749b2b651a1d4f20f45f596a3"
+checksum = "e59824a9ca557a64c4ba26331a2db84f91610e75620a497610287a16edfb52d7"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
- "rand_chacha 0.2.2",
+ "rand_chacha",
  "scale-info",
  "serde",
- "sp-application-crypto",
- "sp-io",
- "sp-runtime",
- "sp-staking",
- "sp-std",
+ "sp-application-crypto 38.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
 name = "pallet-staking-reward-curve"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efca5a4a423427d2c83af5fe07ab648c16b91e3782c3cc23316fe0bd96b4c794"
+checksum = "db5e6b1d8ee9d3f6894c5abd8c3e17737ed738c9854f87bfd16239741b7f4d5d"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -5881,107 +7020,103 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abdecbca3760e93bb757313495ca7d2437e6141e728a2d266a85884c43d74c0e"
+checksum = "c82e375c0a4c4ed079ae49bd2693548bd57178273b37631bcd7e817242d0f2b0"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
 name = "pallet-timestamp"
-version = "31.0.0"
+version = "36.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196720afcbee2f2fd1acfed5a667cffb3914d1311b36adb4d1a3a67d7010e2a5"
+checksum = "14f264c80bef4ac3180e5cba619f319d7855cc89ba91b28b3f752620d9425b88"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
  "sp-storage",
- "sp-timestamp",
+ "sp-timestamp 34.0.0",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dedf412abd258989da4a26946f7e480c4335ffc837baef4ef21ba91cd56ba8ee"
+checksum = "7d6b4889a0a8565cf0d6ecf3feef787c18ad2c529add4d90ec896873cd422eec"
 dependencies = [
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "34.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95122a5483521f5186a008326514e5a579931cc1d36980bbca5bb2b566ca334f"
+checksum = "2496ae1bdf86dd0aeb213d33dccd0edb4abfcead660ada070c81b254ea2cbf75"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "sp-api",
- "sp-blockchain",
- "sp-core",
- "sp-rpc",
- "sp-runtime",
+ "sp-api 34.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
+ "sp-rpc 32.0.0",
+ "sp-runtime 39.0.2",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d4686402973e542eb83da077b46641643834220fbae74a98bcffa762d99e91"
+checksum = "1879d1f608f565d590fc7520a8d9977b868a412910f6381a5ebfa45acf8abcfb"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
+ "sp-api 34.0.0",
+ "sp-runtime 39.0.2",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-treasury"
-version = "31.0.0"
+version = "36.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac957446c936a57417ff7a4866f3463f7f2f49d9bb2daed81093c2de8f0cceaf"
+checksum = "59cdefb4591b3c4e7f21284332b4f83b5681663db0976ff2e9cd78ee6f5a5343"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "impl-trait-for-tuples",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-runtime",
- "sp-std",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -5989,7 +7124,7 @@ name = "pallet-ultraplonk-verifier"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "hex-literal",
  "hp-verifiers",
@@ -5999,27 +7134,26 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serial_test",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-utility"
-version = "32.0.0"
+version = "37.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d770b7c961afe12adc5a727a5d02b44ef09ce38d1dd5923793b3e52e5afde3c"
+checksum = "90fe3943d5d0ed2acc047c6825fa68e7bfa5a9313942474214e3e16e4e3f77a5"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -6027,7 +7161,7 @@ name = "pallet-verifiers"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "hex-literal",
  "hp-poe",
@@ -6037,9 +7171,9 @@ dependencies = [
  "parity-scale-codec",
  "rstest",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
  "sp-std",
 ]
 
@@ -6058,34 +7192,32 @@ dependencies = [
 
 [[package]]
 name = "pallet-vesting"
-version = "32.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ce37af22cc31883dfdafa334c4e1f7cea8f2d4fb964f3aa88d77d5eea7ba94"
+checksum = "271f52d5ec90583ce7bd7d302f89b9ebabe1a820dc3e162fc1e5b14889f3b12c"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
 name = "pallet-whitelist"
-version = "31.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f118e773504b4160eb199d5504d3351d360e9ba64197d72384ee0c5ce1c0e1"
+checksum = "a69f9fedf59efa21db7724c78627e4118e74621e27d90f9b5fa96ad4cff076f3"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-runtime",
- "sp-std",
+ "sp-api 34.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -6093,14 +7225,14 @@ name = "pallet-zksync-verifier"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "hex-literal",
  "hp-verifiers",
  "native",
  "pallet-verifiers",
  "scale-info",
- "sp-core",
+ "sp-core 34.0.0",
 ]
 
 [[package]]
@@ -6584,6 +7716,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
 name = "predicates-core"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6687,6 +7829,17 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-warning"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1eaa7fa0aa1929ffdf7eeb6eac234dde6268914a14ad44d23521ab6a9b258e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "proc-macro-warning"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
@@ -6732,6 +7885,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c99afa9a01501019ac3a14d71d9f94050346f55ca471ce90c799a15c58f61e2"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot 0.12.3",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
 name = "prometheus-client-derive-encode"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6746,14 +7911,14 @@ dependencies = [
 name = "proof-of-existence-rpc"
 version = "0.1.0"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "parity-scale-codec",
  "proof-of-existence-rpc-runtime-api",
- "sc-rpc-api",
- "sp-api",
- "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sc-rpc-api 0.43.0",
+ "sp-api 34.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -6765,9 +7930,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-core",
- "sp-runtime",
+ "sp-api 34.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.2",
  "sp-std",
 ]
 
@@ -6876,11 +8041,32 @@ dependencies = [
  "petgraph",
  "prettyplease 0.1.25",
  "prost 0.11.9",
- "prost-types",
+ "prost-types 0.11.9",
  "regex",
  "syn 1.0.109",
  "tempfile",
  "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+dependencies = [
+ "bytes",
+ "heck 0.5.0",
+ "itertools 0.12.1",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease 0.2.20",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "regex",
+ "syn 2.0.72",
+ "tempfile",
 ]
 
 [[package]]
@@ -6916,6 +8102,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+dependencies = [
+ "prost 0.12.6",
 ]
 
 [[package]]
@@ -6967,7 +8162,20 @@ dependencies = [
  "bytes",
  "quick-protobuf",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
+]
+
+[[package]]
+name = "quick-protobuf-codec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ededb1cd78531627244d51dd0c7139fbe736c7d57af0092a76f0ffb2f56e98"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "quick-protobuf",
+ "thiserror",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -6979,6 +8187,42 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite 0.1.12",
+]
+
+[[package]]
+name = "quinn"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e8b432585672228923edbbf64b8b12c14e1112f62e88737655b4a083dbcd78e"
+dependencies = [
+ "bytes",
+ "pin-project-lite 0.2.14",
+ "quinn-proto 0.9.6",
+ "quinn-udp 0.3.2",
+ "rustc-hash",
+ "rustls 0.20.9",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webpki",
+]
+
+[[package]]
+name = "quinn"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
+dependencies = [
+ "bytes",
+ "futures-io",
+ "pin-project-lite 0.2.14",
+ "quinn-proto 0.10.6",
+ "quinn-udp 0.4.1",
+ "rustc-hash",
+ "rustls 0.21.12",
+ "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -6997,6 +8241,49 @@ dependencies = [
  "tinyvec",
  "tracing",
  "webpki",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring 0.16.20",
+ "rustc-hash",
+ "rustls 0.21.12",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
+dependencies = [
+ "libc",
+ "quinn-proto 0.9.6",
+ "socket2 0.4.10",
+ "tracing",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
+dependencies = [
+ "bytes",
+ "libc",
+ "socket2 0.5.7",
+ "tracing",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7034,18 +8321,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -7782,6 +9059,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rw-stream-sink"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+dependencies = [
+ "futures",
+ "pin-project",
+ "static_assertions",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7812,31 +9100,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97e78771bbc491d4d601afbbf01f5718d6d724d0d971c8581cf5b4c62a9502f7"
 dependencies = [
  "log",
- "sp-core",
+ "sp-core 32.0.0",
+ "sp-wasm-interface",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-allocator"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b975ee3a95eaacb611e7b415737a7fa2db4d8ad7b880cc1b97371b04e95c7903"
+dependencies = [
+ "log",
+ "sp-core 34.0.0",
  "sp-wasm-interface",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.38.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2354138e44624d68245b9490c0d30f73bac7c00f218643ff03fc0dbd1536b98"
+checksum = "bdef7ee4dd39a41957eeafb99c55749f8065a72f46c12e209ed15f4669360a6e"
 dependencies = [
  "futures",
  "futures-timer",
  "log",
  "parity-scale-codec",
- "sc-block-builder",
+ "sc-block-builder 0.42.0",
  "sc-proposer-metrics",
- "sc-telemetry",
- "sc-transaction-pool-api",
- "sp-api",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sc-telemetry 24.0.0",
+ "sc-transaction-pool-api 37.0.0",
+ "sp-api 34.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-consensus 0.40.0",
+ "sp-core 34.0.0",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.2",
  "substrate-prometheus-endpoint",
 ]
 
@@ -7847,13 +9147,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d54ed880c04f6df650dcf4672d7d4a2d08b30e95c51f07b4a3be75eaa535082"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
- "sp-block-builder",
- "sp-blockchain",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-trie",
+ "sp-api 30.0.0",
+ "sp-block-builder 30.0.0",
+ "sp-blockchain 32.0.0",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-trie 33.0.0",
+]
+
+[[package]]
+name = "sc-block-builder"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f666f8ff11f96bf6d90676739eb7ccb6a156a4507634b7af83b94f0aa8195a50"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api 34.0.0",
+ "sp-block-builder 34.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.2",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
@@ -7867,20 +9183,48 @@ dependencies = [
  "log",
  "memmap2 0.9.4",
  "parity-scale-codec",
- "sc-chain-spec-derive",
- "sc-client-api",
- "sc-executor",
- "sc-network",
- "sc-telemetry",
+ "sc-chain-spec-derive 11.0.0",
+ "sc-client-api 32.0.0",
+ "sc-executor 0.36.0",
+ "sc-network 0.38.0",
+ "sc-telemetry 18.0.0",
  "serde",
  "serde_json",
- "sp-blockchain",
- "sp-core",
+ "sp-blockchain 32.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-genesis-builder",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-genesis-builder 0.11.0",
+ "sp-io 34.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
+]
+
+[[package]]
+name = "sc-chain-spec"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9149a7ee8a4a799feb3ed581a288a0ce6ede42fb8b1997806f6a29997cdbd9be"
+dependencies = [
+ "array-bytes 6.2.3",
+ "docify",
+ "log",
+ "memmap2 0.9.4",
+ "parity-scale-codec",
+ "sc-chain-spec-derive 12.0.0",
+ "sc-client-api 37.0.0",
+ "sc-executor 0.40.1",
+ "sc-network 0.44.0",
+ "sc-telemetry 24.0.0",
+ "serde",
+ "serde_json",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing",
+ "sp-genesis-builder 0.15.1",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
+ "sp-state-machine 0.43.0",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -7888,6 +9232,18 @@ name = "sc-chain-spec-derive"
 version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2e80fbdaea194762d4b4b0eec389037c25ad102676203b42d684774ae3019b8"
+dependencies = [
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "sc-chain-spec-derive"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b18cef11d2c69703e0d7c3528202ef4ed1cd2b47a6f063e9e17cad8255b1fa94"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -7907,7 +9263,7 @@ dependencies = [
  "fdlimit",
  "futures",
  "itertools 0.10.5",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "log",
  "names",
  "parity-bip39",
@@ -7915,24 +9271,66 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "rpassword",
- "sc-client-api",
- "sc-client-db",
- "sc-keystore",
- "sc-mixnet",
- "sc-network",
- "sc-service",
- "sc-telemetry",
- "sc-tracing",
+ "sc-client-api 32.0.0",
+ "sc-client-db 0.39.0",
+ "sc-keystore 29.0.0",
+ "sc-mixnet 0.8.0",
+ "sc-network 0.38.0",
+ "sc-service 0.39.0",
+ "sc-telemetry 18.0.0",
+ "sc-tracing 32.0.0",
  "sc-utils",
  "serde",
  "serde_json",
- "sp-blockchain",
- "sp-core",
- "sp-keyring",
- "sp-keystore",
+ "sp-blockchain 32.0.0",
+ "sp-core 32.0.0",
+ "sp-keyring 35.0.0",
+ "sp-keystore 0.38.0",
  "sp-panic-handler",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 35.0.0",
+ "sp-version 33.0.0",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "sc-cli"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b37e08bde78fa7bdf3e30682a6840236de49d2c11960535eb9a9a1a87a0fd3ab"
+dependencies = [
+ "array-bytes 6.2.3",
+ "chrono",
+ "clap",
+ "fdlimit",
+ "futures",
+ "itertools 0.11.0",
+ "libp2p-identity 0.2.9",
+ "log",
+ "names",
+ "parity-bip39",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "regex",
+ "rpassword",
+ "sc-client-api 37.0.0",
+ "sc-client-db 0.44.1",
+ "sc-keystore 33.0.0",
+ "sc-mixnet 0.14.0",
+ "sc-network 0.44.0",
+ "sc-service 0.45.0",
+ "sc-telemetry 24.0.0",
+ "sc-tracing 37.0.1",
+ "sc-utils",
+ "serde",
+ "serde_json",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
+ "sp-keyring 39.0.0",
+ "sp-keystore 0.40.0",
+ "sp-panic-handler",
+ "sp-runtime 39.0.2",
+ "sp-version 37.0.0",
  "thiserror",
  "tokio",
 ]
@@ -7948,20 +9346,48 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sc-executor",
- "sc-transaction-pool-api",
+ "sc-executor 0.36.0",
+ "sc-transaction-pool-api 32.0.0",
  "sc-utils",
- "sp-api",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
+ "sp-api 30.0.0",
+ "sp-blockchain 32.0.0",
+ "sp-consensus 0.36.0",
+ "sp-core 32.0.0",
  "sp-database",
- "sp-externalities",
- "sp-runtime",
- "sp-state-machine",
- "sp-statement-store",
+ "sp-externalities 0.28.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
+ "sp-statement-store 14.0.0",
  "sp-storage",
- "sp-trie",
+ "sp-trie 33.0.0",
+ "substrate-prometheus-endpoint",
+]
+
+[[package]]
+name = "sc-client-api"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e73f1673cdfe658c4be6ffd5113b71c0de74616717e604455dcfd29e15781729"
+dependencies = [
+ "fnv",
+ "futures",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sc-executor 0.40.1",
+ "sc-transaction-pool-api 37.0.0",
+ "sc-utils",
+ "sp-api 34.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-consensus 0.40.0",
+ "sp-core 34.0.0",
+ "sp-database",
+ "sp-externalities 0.29.0",
+ "sp-runtime 39.0.2",
+ "sp-state-machine 0.43.0",
+ "sp-statement-store 18.0.0",
+ "sp-storage",
+ "sp-trie 37.0.0",
  "substrate-prometheus-endpoint",
 ]
 
@@ -7980,16 +9406,43 @@ dependencies = [
  "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sc-client-api",
- "sc-state-db",
+ "sc-client-api 32.0.0",
+ "sc-state-db 0.34.0",
  "schnellru",
  "sp-arithmetic",
- "sp-blockchain",
- "sp-core",
+ "sp-blockchain 32.0.0",
+ "sp-core 32.0.0",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
+ "sp-trie 33.0.0",
+]
+
+[[package]]
+name = "sc-client-db"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5517718f03357325c6f51a780710fac652f125316f3577d1a25a7fbdc1816db2"
+dependencies = [
+ "hash-db",
+ "kvdb",
+ "kvdb-memorydb",
+ "kvdb-rocksdb",
+ "linked-hash-map",
+ "log",
+ "parity-db",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sc-client-api 37.0.0",
+ "sc-state-db 0.36.0",
+ "schnellru",
+ "sp-arithmetic",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
+ "sp-database",
+ "sp-runtime 39.0.2",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
@@ -8001,28 +9454,53 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "log",
- "mockall",
+ "mockall 0.11.4",
  "parking_lot 0.12.3",
- "sc-client-api",
+ "sc-client-api 32.0.0",
  "sc-utils",
  "serde",
- "sp-api",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-api 30.0.0",
+ "sp-blockchain 32.0.0",
+ "sp-consensus 0.36.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
+ "substrate-prometheus-endpoint",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-consensus"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502b55375db80dea8be1336b203eb96c1e22e7c4fa7782dc775bad71688bb91c"
+dependencies = [
+ "async-trait",
+ "futures",
+ "log",
+ "mockall 0.11.4",
+ "parking_lot 0.12.3",
+ "sc-client-api 37.0.0",
+ "sc-network-types",
+ "sc-utils",
+ "serde",
+ "sp-api 34.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-consensus 0.40.0",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.2",
+ "sp-state-machine 0.43.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.38.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe6f127a27ea6ace8e4391ba847ccf21d3512499e1c5e7c300e7e5115642544"
+checksum = "ec4aea13d44497edd2c240c85a3722c2431eaabf7f6d172891d12908504cab1f"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -8033,70 +9511,70 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sc-client-api",
- "sc-consensus",
+ "sc-client-api 37.0.0",
+ "sc-consensus 0.43.0",
  "sc-consensus-epochs",
  "sc-consensus-slots",
- "sc-telemetry",
- "sc-transaction-pool-api",
- "sp-api",
- "sp-application-crypto",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-babe",
- "sp-consensus-slots",
- "sp-core",
+ "sc-telemetry 24.0.0",
+ "sc-transaction-pool-api 37.0.0",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-block-builder 34.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-consensus 0.40.0",
+ "sp-consensus-babe 0.40.0",
+ "sp-consensus-slots 0.40.1",
+ "sp-core 34.0.0",
  "sp-crypto-hashing",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
+ "sp-inherents 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.2",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.38.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c93183245d51eab164ab5513f5ad723964c38f293427d99066f8aed02ae715e1"
+checksum = "63817e1b4fe3d772027d8c96eb6231fbada0f79d5626875016266cc7fda69a10"
 dependencies = [
  "futures",
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "sc-consensus-babe",
  "sc-consensus-epochs",
- "sc-rpc-api",
+ "sc-rpc-api 0.43.0",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-babe",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-consensus 0.40.0",
+ "sp-consensus-babe 0.40.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.2",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.37.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2217e53886dbfd4749eaa2e671f8e59807a2fb711ffa0023b3dc5b30f5db458"
+checksum = "a7258d517642944d4e39d11f77a413825349089e01b6f27819f4349932ff07ec"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
- "sc-client-api",
- "sc-consensus",
- "sp-blockchain",
- "sp-runtime",
+ "sc-client-api 37.0.0",
+ "sc-consensus 0.43.0",
+ "sp-blockchain 37.0.1",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.23.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d666c23af4325c6d2ca35bfe2874917f5dfdd94bfca165ad89b92191489e2d8"
+checksum = "197e67ed725bcad27563c4418254e89e56eb79491cebb278e9926760a1fc16d4"
 dependencies = [
  "ahash 0.8.11",
  "array-bytes 6.2.3",
@@ -8110,75 +9588,76 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "rand 0.8.5",
- "sc-block-builder",
- "sc-chain-spec",
- "sc-client-api",
- "sc-consensus",
- "sc-network",
- "sc-network-common",
+ "sc-block-builder 0.42.0",
+ "sc-chain-spec 37.0.0",
+ "sc-client-api 37.0.0",
+ "sc-consensus 0.43.0",
+ "sc-network 0.44.0",
+ "sc-network-common 0.43.0",
  "sc-network-gossip",
- "sc-network-sync",
- "sc-telemetry",
- "sc-transaction-pool-api",
+ "sc-network-sync 0.43.0",
+ "sc-network-types",
+ "sc-telemetry 24.0.0",
+ "sc-transaction-pool-api 37.0.0",
  "sc-utils",
  "serde_json",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
  "sp-arithmetic",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-grandpa",
- "sp-core",
+ "sp-blockchain 37.0.1",
+ "sp-consensus 0.40.0",
+ "sp-consensus-grandpa 21.0.0",
+ "sp-core 34.0.0",
  "sp-crypto-hashing",
- "sp-keystore",
- "sp-runtime",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.2",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.23.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ff3f1dc9c74563e559725736e07f4817e3429cdfd593e4a8c583d2c8da0894"
+checksum = "6400433a4a8114f5fe7b5673f9332129ac55c71a9f6224c8b2cdf3251a000f10"
 dependencies = [
  "finality-grandpa",
  "futures",
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "log",
  "parity-scale-codec",
- "sc-client-api",
+ "sc-client-api 37.0.0",
  "sc-consensus-grandpa",
- "sc-rpc",
+ "sc-rpc 39.0.0",
  "serde",
- "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.2",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.37.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80382f4da8a76c05c23b84d5c369bb5d617d499749171335e9b47599885fb202"
+checksum = "97f4aab75d55fbeee7437ed6a127a749014f831f12a0b409a71cfc3a42453ccd"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "log",
  "parity-scale-codec",
- "sc-client-api",
- "sc-consensus",
- "sc-telemetry",
+ "sc-client-api 37.0.0",
+ "sc-consensus 0.43.0",
+ "sc-telemetry 24.0.0",
  "sp-arithmetic",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-blockchain 37.0.1",
+ "sp-consensus 0.40.0",
+ "sp-consensus-slots 0.40.1",
+ "sp-core 34.0.0",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.2",
+ "sp-state-machine 0.43.0",
 ]
 
 [[package]]
@@ -8189,18 +9668,42 @@ checksum = "cc6b47b642a92adcabaeadb7d76bd1a02bcf5a93f2b649e81afe8b940107bbda"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sc-executor-common",
- "sc-executor-polkavm",
- "sc-executor-wasmtime",
+ "sc-executor-common 0.33.0",
+ "sc-executor-polkavm 0.30.0",
+ "sc-executor-wasmtime 0.33.1",
  "schnellru",
- "sp-api",
- "sp-core",
- "sp-externalities",
- "sp-io",
+ "sp-api 30.0.0",
+ "sp-core 32.0.0",
+ "sp-externalities 0.28.0",
+ "sp-io 34.0.0",
  "sp-panic-handler",
- "sp-runtime-interface",
- "sp-trie",
- "sp-version",
+ "sp-runtime-interface 27.0.0",
+ "sp-trie 33.0.0",
+ "sp-version 33.0.0",
+ "sp-wasm-interface",
+ "tracing",
+]
+
+[[package]]
+name = "sc-executor"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f0cc0a3728fd033589183460c5a49b2e7545d09dc89a098216ef9e9aadcd9dc"
+dependencies = [
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sc-executor-common 0.35.0",
+ "sc-executor-polkavm 0.32.0",
+ "sc-executor-wasmtime 0.35.0",
+ "schnellru",
+ "sp-api 34.0.0",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-io 38.0.0",
+ "sp-panic-handler",
+ "sp-runtime-interface 28.0.0",
+ "sp-trie 37.0.0",
+ "sp-version 37.0.0",
  "sp-wasm-interface",
  "tracing",
 ]
@@ -8212,7 +9715,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88c61ef111d7ccc7697ee4788654f4f998662db057c27ca2de4b94f20e3e6ed1"
 dependencies = [
  "polkavm",
- "sc-allocator",
+ "sc-allocator 27.0.0",
+ "sp-maybe-compressed-blob",
+ "sp-wasm-interface",
+ "thiserror",
+ "wasm-instrument",
+]
+
+[[package]]
+name = "sc-executor-common"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3b703a33dcb7cddf19176fdf12294b9a6408125836b0f4afee3e6969e7f190"
+dependencies = [
+ "polkavm",
+ "sc-allocator 29.0.0",
  "sp-maybe-compressed-blob",
  "sp-wasm-interface",
  "thiserror",
@@ -8227,7 +9744,19 @@ checksum = "6fb96b22b779ba14f449d114b63efd162f95f1cdf773cdac29f75fe6a250de24"
 dependencies = [
  "log",
  "polkavm",
- "sc-executor-common",
+ "sc-executor-common 0.33.0",
+ "sp-wasm-interface",
+]
+
+[[package]]
+name = "sc-executor-polkavm"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fe58d9cacfab73e5595fa84b80f7bd03efebe54a0574daaeb221a1d1f7ab80"
+dependencies = [
+ "log",
+ "polkavm",
+ "sc-executor-common 0.35.0",
  "sp-wasm-interface",
 ]
 
@@ -8243,9 +9772,28 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "rustix 0.36.17",
- "sc-allocator",
- "sc-executor-common",
- "sp-runtime-interface",
+ "sc-allocator 27.0.0",
+ "sc-executor-common 0.33.0",
+ "sp-runtime-interface 27.0.0",
+ "sp-wasm-interface",
+ "wasmtime",
+]
+
+[[package]]
+name = "sc-executor-wasmtime"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd498f2f77ec1f861c30804f5bfd796d4afcc8ce44ea1f11bfbe2847551d161"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "libc",
+ "log",
+ "parking_lot 0.12.3",
+ "rustix 0.36.17",
+ "sc-allocator 29.0.0",
+ "sc-executor-common 0.35.0",
+ "sp-runtime-interface 28.0.0",
  "sp-wasm-interface",
  "wasmtime",
 ]
@@ -8260,12 +9808,30 @@ dependencies = [
  "futures",
  "futures-timer",
  "log",
- "sc-client-api",
- "sc-network",
- "sc-network-common",
- "sc-network-sync",
- "sp-blockchain",
- "sp-runtime",
+ "sc-client-api 32.0.0",
+ "sc-network 0.38.0",
+ "sc-network-common 0.37.0",
+ "sc-network-sync 0.37.0",
+ "sp-blockchain 32.0.0",
+ "sp-runtime 35.0.0",
+]
+
+[[package]]
+name = "sc-informant"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6dcfaffeeb2d662a26f84706132dcfd294ffd71c4077d0b4f92a6f54db184f6"
+dependencies = [
+ "ansi_term",
+ "futures",
+ "futures-timer",
+ "log",
+ "sc-client-api 37.0.0",
+ "sc-network 0.44.0",
+ "sc-network-common 0.43.0",
+ "sc-network-sync 0.43.0",
+ "sp-blockchain 37.0.1",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -8277,9 +9843,24 @@ dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.3",
  "serde_json",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
+ "sp-application-crypto 34.0.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-keystore"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebd4b5b5713006117641c049cb082e8a439dd6ac5e7b171e5cef5ce1c9f8af8"
+dependencies = [
+ "array-bytes 6.2.3",
+ "parking_lot 0.12.3",
+ "serde_json",
+ "sp-application-crypto 38.0.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
  "thiserror",
 ]
 
@@ -8295,21 +9876,51 @@ dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "log",
  "mixnet",
- "multiaddr",
+ "multiaddr 0.17.1",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sc-client-api",
- "sc-network",
- "sc-transaction-pool-api",
- "sp-api",
- "sp-consensus",
- "sp-core",
- "sp-keystore",
- "sp-mixnet",
- "sp-runtime",
+ "sc-client-api 32.0.0",
+ "sc-network 0.38.0",
+ "sc-transaction-pool-api 32.0.0",
+ "sp-api 30.0.0",
+ "sp-consensus 0.36.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
+ "sp-mixnet 0.8.0",
+ "sp-runtime 35.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-mixnet"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04ac673840824d0357dedee5b952440b469d11f48314ff52ae59049aee7e376d"
+dependencies = [
+ "array-bytes 6.2.3",
+ "arrayvec 0.7.4",
+ "blake2 0.10.6",
+ "bytes",
+ "futures",
+ "futures-timer",
+ "log",
+ "mixnet",
+ "multiaddr 0.18.2",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sc-client-api 37.0.0",
+ "sc-network 0.44.0",
+ "sc-network-types",
+ "sc-transaction-pool-api 37.0.0",
+ "sp-api 34.0.0",
+ "sp-consensus 0.40.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-mixnet 0.12.0",
+ "sp-runtime 39.0.2",
  "thiserror",
 ]
 
@@ -8329,30 +9940,82 @@ dependencies = [
  "futures",
  "futures-timer",
  "ip_network",
- "libp2p",
+ "libp2p 0.51.4",
  "linked_hash_set",
  "log",
- "mockall",
+ "mockall 0.11.4",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "partial_sort",
  "pin-project",
  "rand 0.8.5",
- "sc-client-api",
- "sc-network-common",
+ "sc-client-api 32.0.0",
+ "sc-network-common 0.37.0",
  "sc-utils",
  "serde",
  "serde_json",
  "smallvec",
  "sp-arithmetic",
- "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-blockchain 32.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
  "tokio-stream",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
+ "wasm-timer",
+ "zeroize",
+]
+
+[[package]]
+name = "sc-network"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a4923392c50d67849efca43d1a2601f6150c79fb8ada3383c26ce1b4f28d1af"
+dependencies = [
+ "array-bytes 6.2.3",
+ "async-channel",
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "cid 0.9.0",
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "ip_network",
+ "libp2p 0.52.4",
+ "linked_hash_set",
+ "litep2p",
+ "log",
+ "mockall 0.11.4",
+ "once_cell",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "partial_sort",
+ "pin-project",
+ "prost 0.12.6",
+ "prost-build 0.12.6",
+ "rand 0.8.5",
+ "sc-client-api 37.0.0",
+ "sc-network-common 0.43.0",
+ "sc-network-types",
+ "sc-utils",
+ "schnellru",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "sp-arithmetic",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.2",
+ "substrate-prometheus-endpoint",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "unsigned-varint 0.7.2",
+ "void",
  "wasm-timer",
  "zeroize",
 ]
@@ -8364,18 +10027,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf7cf01e661f39303737596859139fcdd31bd106a979fae0828f3e5b0decce89"
 dependencies = [
  "async-channel",
- "cid",
+ "cid 0.9.0",
  "futures",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "log",
  "prost 0.12.6",
- "prost-build",
- "sc-client-api",
- "sc-network",
- "sp-blockchain",
- "sp-runtime",
+ "prost-build 0.11.9",
+ "sc-client-api 32.0.0",
+ "sc-network 0.38.0",
+ "sp-blockchain 32.0.0",
+ "sp-runtime 35.0.0",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -8387,31 +10050,50 @@ dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "futures",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "parity-scale-codec",
- "prost-build",
- "sc-consensus",
- "sp-consensus",
- "sp-consensus-grandpa",
- "sp-runtime",
+ "prost-build 0.11.9",
+ "sc-consensus 0.37.0",
+ "sp-consensus 0.36.0",
+ "sp-consensus-grandpa 17.0.0",
+ "sp-runtime 35.0.0",
+]
+
+[[package]]
+name = "sc-network-common"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a8bbc9d2600f34d021796bdffbb20bdf4723f98ff3126c765b4c9363bef564"
+dependencies = [
+ "async-trait",
+ "bitflags 1.3.2",
+ "futures",
+ "libp2p-identity 0.2.9",
+ "parity-scale-codec",
+ "prost-build 0.12.6",
+ "sc-consensus 0.43.0",
+ "sc-network-types",
+ "sp-consensus 0.40.0",
+ "sp-consensus-grandpa 21.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.38.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb8b10666371dc53bd9e11dbb99e0763307203ecc70f4d9bb20169cf7ad69db"
+checksum = "2dc2ff366c09b8aba9b0bfd04b991508788203a28da0c66a32625cda7ae8015d"
 dependencies = [
  "ahash 0.8.11",
  "futures",
  "futures-timer",
- "libp2p",
  "log",
- "sc-network",
- "sc-network-common",
- "sc-network-sync",
+ "sc-network 0.44.0",
+ "sc-network-common 0.43.0",
+ "sc-network-sync 0.43.0",
+ "sc-network-types",
  "schnellru",
- "sp-runtime",
+ "sp-runtime 39.0.2",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -8425,16 +10107,38 @@ dependencies = [
  "array-bytes 6.2.3",
  "async-channel",
  "futures",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "log",
  "parity-scale-codec",
  "prost 0.12.6",
- "prost-build",
- "sc-client-api",
- "sc-network",
- "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "prost-build 0.11.9",
+ "sc-client-api 32.0.0",
+ "sc-network 0.38.0",
+ "sp-blockchain 32.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-network-light"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18efef00b71e1a7060fb92dcc433ed4bed625a803b074e0bf4b4cf6e1d90384e"
+dependencies = [
+ "array-bytes 6.2.3",
+ "async-channel",
+ "futures",
+ "log",
+ "parity-scale-codec",
+ "prost 0.12.6",
+ "prost-build 0.12.6",
+ "sc-client-api 37.0.0",
+ "sc-network 0.44.0",
+ "sc-network-types",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.2",
  "thiserror",
 ]
 
@@ -8450,25 +10154,63 @@ dependencies = [
  "fork-tree",
  "futures",
  "futures-timer",
- "libp2p",
+ "libp2p 0.51.4",
  "log",
- "mockall",
+ "mockall 0.11.4",
  "parity-scale-codec",
  "prost 0.12.6",
- "prost-build",
- "sc-client-api",
- "sc-consensus",
- "sc-network",
- "sc-network-common",
+ "prost-build 0.11.9",
+ "sc-client-api 32.0.0",
+ "sc-consensus 0.37.0",
+ "sc-network 0.38.0",
+ "sc-network-common 0.37.0",
  "sc-utils",
  "schnellru",
  "smallvec",
  "sp-arithmetic",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-runtime",
+ "sp-blockchain 32.0.0",
+ "sp-consensus 0.36.0",
+ "sp-consensus-grandpa 17.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "substrate-prometheus-endpoint",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "sc-network-sync"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628881aacdd36235d2725a7ecb13d6445c76ad470ed6e6473fc58c6b98a2417d"
+dependencies = [
+ "array-bytes 6.2.3",
+ "async-channel",
+ "async-trait",
+ "fork-tree",
+ "futures",
+ "futures-timer",
+ "libp2p 0.52.4",
+ "log",
+ "mockall 0.11.4",
+ "parity-scale-codec",
+ "prost 0.12.6",
+ "prost-build 0.12.6",
+ "sc-client-api 37.0.0",
+ "sc-consensus 0.43.0",
+ "sc-network 0.44.0",
+ "sc-network-common 0.43.0",
+ "sc-network-types",
+ "sc-utils",
+ "schnellru",
+ "smallvec",
+ "sp-arithmetic",
+ "sp-blockchain 37.0.1",
+ "sp-consensus 0.40.0",
+ "sp-consensus-grandpa 21.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.2",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -8483,49 +10225,87 @@ checksum = "a1514ca1cc195842970b3a35b80cc14ed002296f3565c19d4659be44ca9255b8"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
- "libp2p",
+ "libp2p 0.51.4",
  "log",
  "parity-scale-codec",
- "sc-network",
- "sc-network-common",
- "sc-network-sync",
+ "sc-network 0.38.0",
+ "sc-network-common 0.37.0",
+ "sc-network-sync 0.37.0",
  "sc-utils",
- "sp-consensus",
- "sp-runtime",
+ "sp-consensus 0.36.0",
+ "sp-runtime 35.0.0",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
-name = "sc-offchain"
-version = "33.0.0"
+name = "sc-network-transactions"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f289809d0c3fd09474637bfe2dc732f41fb211d1241885194232c5d612a641"
+checksum = "8661c677deb9159c291a4dccbdfeba3e1fe5106caea0936fb70d3765a163aa8e"
+dependencies = [
+ "array-bytes 6.2.3",
+ "futures",
+ "log",
+ "parity-scale-codec",
+ "sc-network 0.44.0",
+ "sc-network-common 0.43.0",
+ "sc-network-sync 0.43.0",
+ "sc-network-types",
+ "sc-utils",
+ "sp-consensus 0.40.0",
+ "sp-runtime 39.0.2",
+ "substrate-prometheus-endpoint",
+]
+
+[[package]]
+name = "sc-network-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c372dbda66644a1df0daa8c0d99c36b6f74db7dca213d2416cd84f507125224"
+dependencies = [
+ "bs58 0.5.1",
+ "ed25519-dalek",
+ "libp2p-identity 0.2.9",
+ "litep2p",
+ "log",
+ "multiaddr 0.18.2",
+ "multihash 0.19.1",
+ "rand 0.8.5",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "sc-offchain"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fce257906e8a6f2ffbabe64ce9739ef0e18f272f61e759c975446c752cd74"
 dependencies = [
  "array-bytes 6.2.3",
  "bytes",
  "fnv",
  "futures",
  "futures-timer",
- "hyper",
+ "hyper 0.14.30",
  "hyper-rustls",
- "libp2p",
  "log",
  "num_cpus",
  "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "rand 0.8.5",
- "sc-client-api",
- "sc-network",
- "sc-network-common",
- "sc-transaction-pool-api",
+ "sc-client-api 37.0.0",
+ "sc-network 0.44.0",
+ "sc-network-common 0.43.0",
+ "sc-network-types",
+ "sc-transaction-pool-api 37.0.0",
  "sc-utils",
- "sp-api",
- "sp-core",
- "sp-externalities",
- "sp-keystore",
- "sp-offchain",
- "sp-runtime",
+ "sp-api 34.0.0",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-keystore 0.40.0",
+ "sp-offchain 34.0.0",
+ "sp-runtime 39.0.2",
  "threadpool",
  "tracing",
 ]
@@ -8547,29 +10327,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3d7b43d6ce2c57d90dab64a0eab4673158a7a240119fd3ae934ce95f8ad973f"
 dependencies = [
  "futures",
- "jsonrpsee",
+ "jsonrpsee 0.22.5",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sc-block-builder",
- "sc-chain-spec",
- "sc-client-api",
- "sc-mixnet",
- "sc-rpc-api",
- "sc-tracing",
- "sc-transaction-pool-api",
+ "sc-block-builder 0.37.0",
+ "sc-chain-spec 31.0.0",
+ "sc-client-api 32.0.0",
+ "sc-mixnet 0.8.0",
+ "sc-rpc-api 0.37.0",
+ "sc-tracing 32.0.0",
+ "sc-transaction-pool-api 32.0.0",
  "sc-utils",
  "serde_json",
- "sp-api",
- "sp-blockchain",
- "sp-core",
- "sp-keystore",
- "sp-offchain",
- "sp-rpc",
- "sp-runtime",
- "sp-session",
- "sp-statement-store",
- "sp-version",
+ "sp-api 30.0.0",
+ "sp-blockchain 32.0.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
+ "sp-offchain 30.0.0",
+ "sp-rpc 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
+ "sp-statement-store 14.0.0",
+ "sp-version 33.0.0",
+ "tokio",
+]
+
+[[package]]
+name = "sc-rpc"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ccc910a40803287c65194e232d99bf6e1f9200b04f8dd91433f298687b8bf3f"
+dependencies = [
+ "futures",
+ "jsonrpsee 0.23.2",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sc-block-builder 0.42.0",
+ "sc-chain-spec 37.0.0",
+ "sc-client-api 37.0.0",
+ "sc-mixnet 0.14.0",
+ "sc-rpc-api 0.43.0",
+ "sc-tracing 37.0.1",
+ "sc-transaction-pool-api 37.0.0",
+ "sc-utils",
+ "serde_json",
+ "sp-api 34.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-offchain 34.0.0",
+ "sp-rpc 32.0.0",
+ "sp-runtime 39.0.2",
+ "sp-session 35.0.0",
+ "sp-statement-store 18.0.0",
+ "sp-version 37.0.0",
  "tokio",
 ]
 
@@ -8579,18 +10392,39 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b82060f09f886f59fd19a77cc6668c209e883fc93511e9c441ef84adfea80f36"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.22.5",
  "parity-scale-codec",
- "sc-chain-spec",
- "sc-mixnet",
- "sc-transaction-pool-api",
+ "sc-chain-spec 31.0.0",
+ "sc-mixnet 0.8.0",
+ "sc-transaction-pool-api 32.0.0",
  "scale-info",
  "serde",
  "serde_json",
- "sp-core",
- "sp-rpc",
- "sp-runtime",
- "sp-version",
+ "sp-core 32.0.0",
+ "sp-rpc 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-version 33.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-rpc-api"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "575a098a1c59d15bec2df388437474334b76c512e9dd92b0f275801906303354"
+dependencies = [
+ "jsonrpsee 0.23.2",
+ "parity-scale-codec",
+ "sc-chain-spec 37.0.0",
+ "sc-mixnet 0.14.0",
+ "sc-transaction-pool-api 37.0.0",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "sp-core 34.0.0",
+ "sp-rpc 32.0.0",
+ "sp-runtime 39.0.2",
+ "sp-version 37.0.0",
  "thiserror",
 ]
 
@@ -8602,15 +10436,38 @@ checksum = "76f6d0924de213aa5c72a47c7bd0d7668531c5845e832d1ac5c33c96d0ff7b9b"
 dependencies = [
  "futures",
  "governor",
- "http",
- "hyper",
- "jsonrpsee",
+ "http 0.2.12",
+ "hyper 0.14.30",
+ "jsonrpsee 0.22.5",
  "log",
  "serde_json",
  "substrate-prometheus-endpoint",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.4.4",
+]
+
+[[package]]
+name = "sc-rpc-server"
+version = "16.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c14c236a01e03f55f16b92d89fd902cf2e4e9887357a3c36827a1e39b799c6b"
+dependencies = [
+ "forwarded-header-value",
+ "futures",
+ "governor",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.5.0",
+ "ip_network",
+ "jsonrpsee 0.23.2",
+ "log",
+ "serde",
+ "serde_json",
+ "substrate-prometheus-endpoint",
+ "tokio",
+ "tower",
+ "tower-http 0.5.2",
 ]
 
 [[package]]
@@ -8623,23 +10480,56 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
- "jsonrpsee",
+ "jsonrpsee 0.22.5",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "rand 0.8.5",
- "sc-chain-spec",
- "sc-client-api",
- "sc-rpc",
- "sc-transaction-pool-api",
+ "sc-chain-spec 31.0.0",
+ "sc-client-api 32.0.0",
+ "sc-rpc 33.0.0",
+ "sc-transaction-pool-api 32.0.0",
  "sc-utils",
  "serde",
- "sp-api",
- "sp-blockchain",
- "sp-core",
- "sp-rpc",
- "sp-runtime",
- "sp-version",
+ "sp-api 30.0.0",
+ "sp-blockchain 32.0.0",
+ "sp-core 32.0.0",
+ "sp-rpc 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-version 33.0.0",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "sc-rpc-spec-v2"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "934087c0aae2642327e07070ae3739ae82bbadaf876fadcff0c9b19c37a87ada"
+dependencies = [
+ "array-bytes 6.2.3",
+ "futures",
+ "futures-util",
+ "hex",
+ "jsonrpsee 0.23.2",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand 0.8.5",
+ "sc-chain-spec 37.0.0",
+ "sc-client-api 37.0.0",
+ "sc-rpc 39.0.0",
+ "sc-transaction-pool-api 37.0.0",
+ "sc-utils",
+ "schnellru",
+ "serde",
+ "sp-api 34.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
+ "sp-rpc 32.0.0",
+ "sp-runtime 39.0.2",
+ "sp-version 37.0.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -8656,51 +10546,116 @@ dependencies = [
  "exit-future",
  "futures",
  "futures-timer",
- "jsonrpsee",
+ "jsonrpsee 0.22.5",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "sc-chain-spec",
- "sc-client-api",
- "sc-client-db",
- "sc-consensus",
- "sc-executor",
- "sc-informant",
- "sc-keystore",
- "sc-network",
+ "sc-chain-spec 31.0.0",
+ "sc-client-api 32.0.0",
+ "sc-client-db 0.39.0",
+ "sc-consensus 0.37.0",
+ "sc-executor 0.36.0",
+ "sc-informant 0.37.0",
+ "sc-keystore 29.0.0",
+ "sc-network 0.38.0",
  "sc-network-bitswap",
- "sc-network-common",
- "sc-network-light",
- "sc-network-sync",
- "sc-network-transactions",
- "sc-rpc",
- "sc-rpc-server",
- "sc-rpc-spec-v2",
- "sc-sysinfo",
- "sc-telemetry",
- "sc-tracing",
- "sc-transaction-pool",
- "sc-transaction-pool-api",
+ "sc-network-common 0.37.0",
+ "sc-network-light 0.37.0",
+ "sc-network-sync 0.37.0",
+ "sc-network-transactions 0.37.0",
+ "sc-rpc 33.0.0",
+ "sc-rpc-server 15.0.0",
+ "sc-rpc-spec-v2 0.38.0",
+ "sc-sysinfo 31.0.0",
+ "sc-telemetry 18.0.0",
+ "sc-tracing 32.0.0",
+ "sc-transaction-pool 32.0.0",
+ "sc-transaction-pool-api 32.0.0",
  "sc-utils",
  "schnellru",
  "serde",
  "serde_json",
- "sp-api",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-externalities",
- "sp-keystore",
- "sp-runtime",
- "sp-session",
- "sp-state-machine",
+ "sp-api 30.0.0",
+ "sp-blockchain 32.0.0",
+ "sp-consensus 0.36.0",
+ "sp-core 32.0.0",
+ "sp-externalities 0.28.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
+ "sp-session 31.0.0",
+ "sp-state-machine 0.39.0",
  "sp-storage",
- "sp-transaction-pool",
- "sp-transaction-storage-proof",
- "sp-trie",
- "sp-version",
+ "sp-transaction-pool 30.0.0",
+ "sp-transaction-storage-proof 30.0.0",
+ "sp-trie 33.0.0",
+ "sp-version 33.0.0",
+ "static_init",
+ "substrate-prometheus-endpoint",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "sc-service"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd9eb103478c93e3a9325fb9c07d2c6a507cd04934954c930fc33a1e0791010b"
+dependencies = [
+ "async-trait",
+ "directories",
+ "exit-future",
+ "futures",
+ "futures-timer",
+ "jsonrpsee 0.23.2",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "rand 0.8.5",
+ "sc-chain-spec 37.0.0",
+ "sc-client-api 37.0.0",
+ "sc-client-db 0.44.1",
+ "sc-consensus 0.43.0",
+ "sc-executor 0.40.1",
+ "sc-informant 0.43.0",
+ "sc-keystore 33.0.0",
+ "sc-network 0.44.0",
+ "sc-network-common 0.43.0",
+ "sc-network-light 0.43.0",
+ "sc-network-sync 0.43.0",
+ "sc-network-transactions 0.43.0",
+ "sc-network-types",
+ "sc-rpc 39.0.0",
+ "sc-rpc-server 16.0.2",
+ "sc-rpc-spec-v2 0.44.0",
+ "sc-sysinfo 37.0.0",
+ "sc-telemetry 24.0.0",
+ "sc-tracing 37.0.1",
+ "sc-transaction-pool 37.0.0",
+ "sc-transaction-pool-api 37.0.0",
+ "sc-utils",
+ "schnellru",
+ "serde",
+ "serde_json",
+ "sp-api 34.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-consensus 0.40.0",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.2",
+ "sp-session 35.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-storage",
+ "sp-transaction-pool 34.0.0",
+ "sp-transaction-storage-proof 34.0.0",
+ "sp-trie 37.0.0",
+ "sp-version 37.0.0",
  "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
@@ -8719,7 +10674,19 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sp-core",
+ "sp-core 32.0.0",
+]
+
+[[package]]
+name = "sc-state-db"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f689d0b97c1bbdb2ca31b5f202bda195947f85c7fef990651cad202b99de896b"
+dependencies = [
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sp-core 34.0.0",
 ]
 
 [[package]]
@@ -8735,12 +10702,34 @@ dependencies = [
  "rand 0.8.5",
  "rand_pcg",
  "regex",
- "sc-telemetry",
+ "sc-telemetry 18.0.0",
  "serde",
  "serde_json",
- "sp-core",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-io",
+ "sp-io 34.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "sc-sysinfo"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ce11152bd7a2b01713e71de71a5610067bd1b3509aa207e3d87f5ee53dd328"
+dependencies = [
+ "derive_more",
+ "futures",
+ "libc",
+ "log",
+ "rand 0.8.5",
+ "rand_pcg",
+ "regex",
+ "sc-telemetry 24.0.0",
+ "serde",
+ "serde_json",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing",
+ "sp-io 38.0.0",
  "sp-std",
 ]
 
@@ -8752,11 +10741,32 @@ checksum = "72a5a306d8c75e61e8c59e18b92886f85db6b4102c4669240eca101954fec79e"
 dependencies = [
  "chrono",
  "futures",
- "libp2p",
+ "libp2p 0.51.4",
  "log",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
+ "sc-utils",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "wasm-timer",
+]
+
+[[package]]
+name = "sc-telemetry"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b59589eadf05088221cc60b6d9f68f89208262ae9b1e4fb8704eefe7de48845"
+dependencies = [
+ "chrono",
+ "futures",
+ "libp2p 0.52.4",
+ "log",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "rand 0.8.5",
+ "sc-network 0.44.0",
  "sc-utils",
  "serde",
  "serde_json",
@@ -8780,19 +10790,49 @@ dependencies = [
  "parking_lot 0.12.3",
  "regex",
  "rustc-hash",
- "sc-client-api",
+ "sc-client-api 32.0.0",
  "sc-tracing-proc-macro",
  "serde",
- "sp-api",
- "sp-blockchain",
- "sp-core",
- "sp-rpc",
- "sp-runtime",
+ "sp-api 30.0.0",
+ "sp-blockchain 32.0.0",
+ "sp-core 32.0.0",
+ "sp-rpc 30.0.0",
+ "sp-runtime 35.0.0",
  "sp-tracing",
  "thiserror",
  "tracing",
- "tracing-log",
- "tracing-subscriber",
+ "tracing-log 0.1.4",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
+name = "sc-tracing"
+version = "37.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604130246c4f6c2a2633f320bde95e7122383385c779b263eb03b714d92758a"
+dependencies = [
+ "chrono",
+ "console",
+ "is-terminal",
+ "lazy_static",
+ "libc",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rustc-hash",
+ "sc-client-api 37.0.0",
+ "sc-tracing-proc-macro",
+ "serde",
+ "sp-api 34.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
+ "sp-rpc 32.0.0",
+ "sp-runtime 39.0.2",
+ "sp-tracing",
+ "thiserror",
+ "tracing",
+ "tracing-log 0.2.0",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -8820,17 +10860,45 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sc-client-api",
- "sc-transaction-pool-api",
+ "sc-client-api 32.0.0",
+ "sc-transaction-pool-api 32.0.0",
  "sc-utils",
  "serde",
- "sp-api",
- "sp-blockchain",
- "sp-core",
+ "sp-api 30.0.0",
+ "sp-blockchain 32.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-runtime",
+ "sp-runtime 35.0.0",
  "sp-tracing",
- "sp-transaction-pool",
+ "sp-transaction-pool 30.0.0",
+ "substrate-prometheus-endpoint",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-transaction-pool"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f716ef0dc78458f6ecb831cdb3b60ec804c1ed93313d7f98661beb5438dbbf71"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-timer",
+ "linked-hash-map",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sc-client-api 37.0.0",
+ "sc-transaction-pool-api 37.0.0",
+ "sc-utils",
+ "serde",
+ "sp-api 34.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing",
+ "sp-runtime 39.0.2",
+ "sp-tracing",
+ "sp-transaction-pool 34.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -8846,9 +10914,26 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "serde",
- "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-blockchain 32.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-transaction-pool-api"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02936289a079360935685eee5400311994b25e9edb2420a3c4247d419a77f46"
+dependencies = [
+ "async-trait",
+ "futures",
+ "log",
+ "parity-scale-codec",
+ "serde",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.2",
  "thiserror",
 ]
 
@@ -8965,6 +11050,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sctp-proto"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6220f78bb44c15f326b0596113305f6101097a18755d53727a575c97e09fb24"
+dependencies = [
+ "bytes",
+ "crc",
+ "fxhash",
+ "log",
+ "rand 0.8.5",
+ "slab",
+ "thiserror",
+]
+
+[[package]]
 name = "sdd"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9060,10 +11160,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
-name = "serde"
-version = "1.0.204"
+name = "send_wrapper"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+
+[[package]]
+name = "serde"
+version = "1.0.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -9079,9 +11185,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9090,9 +11196,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.121"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -9188,6 +11294,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.7",
+ "sha1-asm",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1-asm"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "286acebaf8b67c1130aedffad26f594eff0c1292389158135327d2e23aed582b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9266,6 +11404,15 @@ dependencies = [
  "num-traits",
  "paste",
  "wide",
+]
+
+[[package]]
+name = "simple-dns"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae9a3fcdadafb6d97f4c0e007e4247b114ee0f119f650c3cbf3a8b3a1479694"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -9397,11 +11544,27 @@ dependencies = [
  "bytes",
  "flate2",
  "futures",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1",
+ "sha-1 0.9.8",
+]
+
+[[package]]
+name = "soketto"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37468c595637c10857701c990f93a40ce0e357cedb0953d1c26c8d8027f9bb53"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
 ]
 
 [[package]]
@@ -9414,16 +11577,39 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api-proc-macro",
- "sp-core",
- "sp-externalities",
+ "sp-api-proc-macro 18.0.0",
+ "sp-core 32.0.0",
+ "sp-externalities 0.28.0",
  "sp-metadata-ir",
- "sp-runtime",
- "sp-runtime-interface",
- "sp-state-machine",
+ "sp-runtime 35.0.0",
+ "sp-runtime-interface 27.0.0",
+ "sp-state-machine 0.39.0",
  "sp-std",
- "sp-trie",
- "sp-version",
+ "sp-trie 33.0.0",
+ "sp-version 33.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-api"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbce492e0482134128b7729ea36f5ef1a9f9b4de2d48ff8dde7b5e464e28ce75"
+dependencies = [
+ "docify",
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api-proc-macro 20.0.0",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-metadata-ir",
+ "sp-runtime 39.0.2",
+ "sp-runtime-interface 28.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
+ "sp-version 37.0.0",
  "thiserror",
 ]
 
@@ -9443,6 +11629,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-api-proc-macro"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9aadf9e97e694f0e343978aa632938c5de309cbcc8afed4136cb71596737278"
+dependencies = [
+ "Inflector",
+ "blake2 0.10.6",
+ "expander",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "sp-application-crypto"
 version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9451,9 +11652,22 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
  "sp-std",
+]
+
+[[package]]
+name = "sp-application-crypto"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8133012faa5f75b2f0b1619d9f720c1424ac477152c143e5f7dbde2fe1a958"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
 ]
 
 [[package]]
@@ -9478,9 +11692,20 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "466eaa1fe1745e9456a5e5afc033b67a52211463a137ea3551bff36b4d72ce03"
 dependencies = [
- "sp-api",
- "sp-inherents",
- "sp-runtime",
+ "sp-api 30.0.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
+]
+
+[[package]]
+name = "sp-block-builder"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74738809461e3d4bd707b5b94e0e0c064a623a74a6a8fe5c98514417a02858dd"
+dependencies = [
+ "sp-api 34.0.0",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -9494,12 +11719,32 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "schnellru",
- "sp-api",
- "sp-consensus",
+ "sp-api 30.0.0",
+ "sp-consensus 0.36.0",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
  "thiserror",
+]
+
+[[package]]
+name = "sp-blockchain"
+version = "37.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a309eecd6b5689f57e67181deaa628d9c8951db1ba0d26f07c69e14dffdc4765"
+dependencies = [
+ "futures",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "schnellru",
+ "sp-api 34.0.0",
+ "sp-consensus 0.40.0",
+ "sp-core 34.0.0",
+ "sp-database",
+ "sp-runtime 39.0.2",
+ "sp-state-machine 0.43.0",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -9511,10 +11756,26 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-consensus"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce75efd1e164be667a53c20182c45b4c2abe325abcbd21fc292b82be5b9240f7"
+dependencies = [
+ "async-trait",
+ "futures",
+ "log",
+ "sp-core 34.0.0",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.2",
+ "sp-state-machine 0.43.0",
  "thiserror",
 ]
 
@@ -9527,12 +11788,12 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
- "sp-consensus-slots",
- "sp-inherents",
- "sp-runtime",
- "sp-timestamp",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-consensus-slots 0.36.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-timestamp 30.0.0",
 ]
 
 [[package]]
@@ -9545,13 +11806,32 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-timestamp",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-consensus-slots 0.36.0",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-timestamp 30.0.0",
+]
+
+[[package]]
+name = "sp-consensus-babe"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ee95e17ee8dcd14db7d584b899a426565ca9abe5a266ab82277977fc547f86"
+dependencies = [
+ "async-trait",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-consensus-slots 0.40.1",
+ "sp-core 34.0.0",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.2",
+ "sp-timestamp 34.0.0",
 ]
 
 [[package]]
@@ -9565,11 +11845,29 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
+]
+
+[[package]]
+name = "sp-consensus-grandpa"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "587b791efe6c5f18e09dbbaf1ece0ee7b5fe51602c233e7151a3676b0de0260b"
+dependencies = [
+ "finality-grandpa",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -9581,7 +11879,19 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-timestamp",
+ "sp-timestamp 30.0.0",
+]
+
+[[package]]
+name = "sp-consensus-slots"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbafb7ed44f51c22fa277fb39b33dc601fa426133a8e2b53f3f46b10f07fba43"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-timestamp 34.0.0",
 ]
 
 [[package]]
@@ -9596,7 +11906,7 @@ dependencies = [
  "bounded-collections",
  "bs58 0.5.1",
  "dyn-clonable",
- "ed25519-zebra",
+ "ed25519-zebra 3.1.0",
  "futures",
  "hash-db",
  "hash256-std-hasher",
@@ -9619,8 +11929,55 @@ dependencies = [
  "serde",
  "sp-crypto-hashing",
  "sp-debug-derive",
- "sp-externalities",
- "sp-runtime-interface",
+ "sp-externalities 0.28.0",
+ "sp-runtime-interface 27.0.0",
+ "sp-std",
+ "sp-storage",
+ "ss58-registry",
+ "substrate-bip39",
+ "thiserror",
+ "tracing",
+ "w3f-bls",
+ "zeroize",
+]
+
+[[package]]
+name = "sp-core"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c961a5e33fb2962fa775c044ceba43df9c6f917e2c35d63bfe23738468fa76a7"
+dependencies = [
+ "array-bytes 6.2.3",
+ "bitflags 1.3.2",
+ "blake2 0.10.6",
+ "bounded-collections",
+ "bs58 0.5.1",
+ "dyn-clonable",
+ "ed25519-zebra 4.0.3",
+ "futures",
+ "hash-db",
+ "hash256-std-hasher",
+ "impl-serde",
+ "itertools 0.11.0",
+ "k256",
+ "libsecp256k1",
+ "log",
+ "merlin",
+ "parity-bip39",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "paste",
+ "primitive-types",
+ "rand 0.8.5",
+ "scale-info",
+ "schnorrkel",
+ "secp256k1",
+ "secrecy",
+ "serde",
+ "sp-crypto-hashing",
+ "sp-debug-derive",
+ "sp-externalities 0.29.0",
+ "sp-runtime-interface 28.0.0",
  "sp-std",
  "sp-storage",
  "ss58-registry",
@@ -9689,14 +12046,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-externalities"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a904407d61cb94228c71b55a9d3708e9d6558991f9e83bd42bd91df37a159d30"
+dependencies = [
+ "environmental",
+ "parity-scale-codec",
+ "sp-storage",
+]
+
+[[package]]
 name = "sp-genesis-builder"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8a812b56fb4ed6a598ad7b43be127702aba1f7351ad4916f5bab995054cdc5"
 dependencies = [
  "serde_json",
- "sp-api",
- "sp-runtime",
+ "sp-api 30.0.0",
+ "sp-runtime 35.0.0",
+]
+
+[[package]]
+name = "sp-genesis-builder"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a646ed222fd86d5680faa4a8967980eb32f644cae6c8523e1c689a6deda3e8"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde_json",
+ "sp-api 34.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -9709,7 +12090,21 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 35.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-inherents"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afffbddc380d99a90c459ba1554bbbc01d62e892de9f1485af6940b89c4c0d57"
+dependencies = [
+ "async-trait",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 39.0.2",
  "thiserror",
 ]
 
@@ -9727,15 +12122,42 @@ dependencies = [
  "polkavm-derive",
  "rustversion",
  "secp256k1",
- "sp-core",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-externalities",
- "sp-keystore",
- "sp-runtime-interface",
- "sp-state-machine",
+ "sp-externalities 0.28.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime-interface 27.0.0",
+ "sp-state-machine 0.39.0",
  "sp-std",
  "sp-tracing",
- "sp-trie",
+ "sp-trie 33.0.0",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "sp-io"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ef7eb561bb4839cc8424ce58c5ea236cbcca83f26fcc0426d8decfe8aa97d4"
+dependencies = [
+ "bytes",
+ "docify",
+ "ed25519-dalek",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec",
+ "polkavm-derive",
+ "rustversion",
+ "secp256k1",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing",
+ "sp-externalities 0.29.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime-interface 28.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-tracing",
+ "sp-trie 37.0.0",
  "tracing",
  "tracing-core",
 ]
@@ -9746,8 +12168,19 @@ version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "089da5d08c4a6b4a36de664de287f4a391ac338e351a923b79aedfc46162f201"
 dependencies = [
- "sp-core",
- "sp-runtime",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+ "strum 0.26.3",
+]
+
+[[package]]
+name = "sp-keyring"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c0e20624277f578b27f44ecfbe2ebc2e908488511ee2c900c5281599f700ab3"
+dependencies = [
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.2",
  "strum 0.26.3",
 ]
 
@@ -9759,8 +12192,20 @@ checksum = "4e6c7a7abd860a5211a356cf9d5fcabf0eb37d997985e5d722b6b33dcc815528"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sp-core",
- "sp-externalities",
+ "sp-core 32.0.0",
+ "sp-externalities 0.28.0",
+]
+
+[[package]]
+name = "sp-keystore"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0248b4d784cb4a01472276928977121fa39d977a5bb24793b6b15e64b046df42"
+dependencies = [
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
 ]
 
 [[package]]
@@ -9792,22 +12237,34 @@ checksum = "01ba1e6ceede3aa5e36ee161dc02f1b294a659823887cefc4f0f2fce589e3c11"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+]
+
+[[package]]
+name = "sp-mixnet"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0b017dd54823b6e62f9f7171a1df350972e5c6d0bf17e0c2f78680b5c31942"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
 ]
 
 [[package]]
 name = "sp-npos-elections"
-version = "30.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae4f90a3a36f052f4f9aa6f6ab1d59cf6f895f3a939f40dbe1f3e14907a2e31"
+checksum = "af922f112c7c1ed199eabe14f12a82ceb75e1adf0804870eccfbcf3399492847"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-core",
- "sp-runtime",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -9816,9 +12273,20 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50efea44dfc8e40c59e9f9099c6a4f64dc750ad224fd8dbf9aec12fc857fa145"
 dependencies = [
- "sp-api",
- "sp-core",
- "sp-runtime",
+ "sp-api 30.0.0",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+]
+
+[[package]]
+name = "sp-offchain"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d9de237d72ecffd07f90826eef18360208b16d8de939d54e61591fac0fcbf99"
+dependencies = [
+ "sp-api 34.0.0",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -9840,7 +12308,18 @@ checksum = "51104c3cab9d6c9e8361adbd487dd409a8343e740744fb0b3f983bc775fd1847"
 dependencies = [
  "rustc-hash",
  "serde",
- "sp-core",
+ "sp-core 32.0.0",
+]
+
+[[package]]
+name = "sp-rpc"
+version = "32.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45458f0955870a92b3969098d4f1f4e9b55b4282d9f1dc112a51bb5bb6584900"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "sp-core 34.0.0",
 ]
 
 [[package]]
@@ -9860,12 +12339,39 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto",
+ "sp-application-crypto 34.0.0",
  "sp-arithmetic",
- "sp-core",
- "sp-io",
+ "sp-core 32.0.0",
+ "sp-io 34.0.0",
  "sp-std",
  "sp-weights",
+]
+
+[[package]]
+name = "sp-runtime"
+version = "39.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658f23be7c79a85581029676a73265c107c5469157e3444c8c640fdbaa8bfed0"
+dependencies = [
+ "docify",
+ "either",
+ "hash256-std-hasher",
+ "impl-trait-for-tuples",
+ "log",
+ "num-traits",
+ "parity-scale-codec",
+ "paste",
+ "rand 0.8.5",
+ "scale-info",
+ "serde",
+ "simple-mermaid",
+ "sp-application-crypto 38.0.0",
+ "sp-arithmetic",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-std",
+ "sp-weights",
+ "tracing",
 ]
 
 [[package]]
@@ -9879,7 +12385,27 @@ dependencies = [
  "parity-scale-codec",
  "polkavm-derive",
  "primitive-types",
- "sp-externalities",
+ "sp-externalities 0.28.0",
+ "sp-runtime-interface-proc-macro",
+ "sp-std",
+ "sp-storage",
+ "sp-tracing",
+ "sp-wasm-interface",
+ "static_assertions",
+]
+
+[[package]]
+name = "sp-runtime-interface"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985eb981f40c689c6a0012c937b68ed58dabb4341d06f2dfe4dfd5ed72fa4017"
+dependencies = [
+ "bytes",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "polkavm-derive",
+ "primitive-types",
+ "sp-externalities 0.29.0",
  "sp-runtime-interface-proc-macro",
  "sp-std",
  "sp-storage",
@@ -9910,11 +12436,26 @@ checksum = "3d66f0f2f00e4c520deae07eeab7acf04c1a41dd875c7a4689e4e4302fb89925"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
- "sp-staking",
+ "sp-api 30.0.0",
+ "sp-core 32.0.0",
+ "sp-keystore 0.38.0",
+ "sp-runtime 35.0.0",
+ "sp-staking 30.0.0",
+]
+
+[[package]]
+name = "sp-session"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d04fcd2d1270038be94d00103e8e95f7fbab9075dcc78096b91d8931ee970d73"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api 34.0.0",
+ "sp-core 34.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.2",
+ "sp-staking 34.0.0",
 ]
 
 [[package]]
@@ -9927,8 +12468,22 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-runtime",
+ "sp-core 32.0.0",
+ "sp-runtime 35.0.0",
+]
+
+[[package]]
+name = "sp-staking"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143a764cacbab58347d8b2fd4c8909031fb0888d7b02a0ec9fa44f81f780d732"
+dependencies = [
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -9943,13 +12498,34 @@ dependencies = [
  "parking_lot 0.12.3",
  "rand 0.8.5",
  "smallvec",
- "sp-core",
- "sp-externalities",
+ "sp-core 32.0.0",
+ "sp-externalities 0.28.0",
  "sp-panic-handler",
- "sp-trie",
+ "sp-trie 33.0.0",
  "thiserror",
  "tracing",
- "trie-db",
+ "trie-db 0.28.0",
+]
+
+[[package]]
+name = "sp-state-machine"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "930104d6ae882626e8880d9b1578da9300655d337a3ffb45e130c608b6c89660"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand 0.8.5",
+ "smallvec",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-panic-handler",
+ "sp-trie 37.0.0",
+ "thiserror",
+ "tracing",
+ "trie-db 0.29.1",
 ]
 
 [[package]]
@@ -9966,13 +12542,38 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "sha2 0.10.8",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
+ "sp-api 30.0.0",
+ "sp-application-crypto 34.0.0",
+ "sp-core 32.0.0",
  "sp-crypto-hashing",
- "sp-externalities",
- "sp-runtime",
- "sp-runtime-interface",
+ "sp-externalities 0.28.0",
+ "sp-runtime 35.0.0",
+ "sp-runtime-interface 27.0.0",
+ "thiserror",
+ "x25519-dalek 2.0.1",
+]
+
+[[package]]
+name = "sp-statement-store"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c219bc34ef4d1f9835f3ed881f965643c32034fcc030eb33b759dadbc802c1c2"
+dependencies = [
+ "aes-gcm",
+ "curve25519-dalek 4.1.3",
+ "ed25519-dalek",
+ "hkdf",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "scale-info",
+ "sha2 0.10.8",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing",
+ "sp-externalities 0.29.0",
+ "sp-runtime 39.0.2",
+ "sp-runtime-interface 28.0.0",
  "thiserror",
  "x25519-dalek 2.0.1",
 ]
@@ -10004,21 +12605,34 @@ checksum = "d6d3965ef60cc066fcc01dbcb7837404f40de8ac58f1115e3a3a1d6550575ff6"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-timestamp"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a1cb4df653d62ccc0dbce1db45d1c9443ec60247ee9576962d24da4c9c6f07"
+dependencies = [
+ "async-trait",
+ "parity-scale-codec",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.2",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-tracing"
-version = "17.0.0"
+version = "17.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b3decf116db9f1dfaf1f1597096b043d0e12c952d3bcdc018c6d6b77deec7e"
+checksum = "cf641a1d17268c8fcfdb8e0fa51a79c2d4222f4cfda5f3944dbdbc384dced8d5"
 dependencies = [
  "parity-scale-codec",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]
@@ -10027,8 +12641,18 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddae32e6935eedda993b7371b79e69af901a277e11be2bbd6d9bc7643b49cb"
 dependencies = [
- "sp-api",
- "sp-runtime",
+ "sp-api 30.0.0",
+ "sp-runtime 35.0.0",
+]
+
+[[package]]
+name = "sp-transaction-pool"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4bf251059485a7dd38fe4afeda8792983511cc47f342ff4695e2dcae6b5247"
+dependencies = [
+ "sp-api 34.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -10040,10 +12664,25 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-trie",
+ "sp-core 32.0.0",
+ "sp-inherents 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-trie 33.0.0",
+]
+
+[[package]]
+name = "sp-transaction-storage-proof"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c765c2e9817d95f13d42a9f2295c60723464669765c6e5acbacebd2f54932f67"
+dependencies = [
+ "async-trait",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.2",
+ "sp-trie 37.0.0",
 ]
 
 [[package]]
@@ -10062,11 +12701,35 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "schnellru",
- "sp-core",
- "sp-externalities",
+ "sp-core 32.0.0",
+ "sp-externalities 0.28.0",
  "thiserror",
  "tracing",
- "trie-db",
+ "trie-db 0.28.0",
+ "trie-root",
+]
+
+[[package]]
+name = "sp-trie"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6282aef9f4b6ecd95a67a45bcdb67a71f4a4155c09a53c10add4ffe823db18cd"
+dependencies = [
+ "ahash 0.8.11",
+ "hash-db",
+ "lazy_static",
+ "memory-db",
+ "nohash-hasher",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand 0.8.5",
+ "scale-info",
+ "schnellru",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "thiserror",
+ "tracing",
+ "trie-db 0.29.1",
  "trie-root",
 ]
 
@@ -10082,7 +12745,25 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime",
+ "sp-runtime 35.0.0",
+ "sp-std",
+ "sp-version-proc-macro",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-version"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d521a405707b5be561367cd3d442ff67588993de24062ce3adefcf8437ee9fe1"
+dependencies = [
+ "impl-serde",
+ "parity-scale-codec",
+ "parity-wasm",
+ "scale-info",
+ "serde",
+ "sp-crypto-hashing-proc-macro",
+ "sp-runtime 39.0.2",
  "sp-std",
  "sp-version-proc-macro",
  "thiserror",
@@ -10102,9 +12783,9 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "21.0.0"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b04b919e150b4736d85089d49327eab65507deb1485eec929af69daa2278eb3"
+checksum = "b066baa6d57951600b14ffe1243f54c47f9c23dd89c262e17ca00ae8dca58be9"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -10229,6 +12910,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "str0m"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6706347e49b13373f7ddfafad47df7583ed52083d6fc8a594eb2c80497ef959d"
+dependencies = [
+ "combine",
+ "crc",
+ "fastrand",
+ "hmac 0.12.1",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "sctp-proto",
+ "serde",
+ "sha-1 0.10.1",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10325,22 +13026,23 @@ checksum = "b285e7d183a32732fdc119f3d81b7915790191fad602b7c709ef247073c77a2e"
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "32.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949d14f7bb2a53b77985bd17a8eb2e9edf8d5bbf4409e9acb036fa3bf7310d8f"
+checksum = "bdf4468637471dd481811d0d1ffaf8e8a98165d9ad6b586bfb2911ca1cb081f5"
 dependencies = [
+ "docify",
  "frame-system-rpc-runtime-api",
  "futures",
- "jsonrpsee",
+ "jsonrpsee 0.23.2",
  "log",
  "parity-scale-codec",
- "sc-rpc-api",
- "sc-transaction-pool-api",
- "sp-api",
- "sp-block-builder",
- "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sc-rpc-api 0.43.0",
+ "sc-transaction-pool-api 37.0.0",
+ "sp-api 34.0.0",
+ "sp-block-builder 34.0.0",
+ "sp-blockchain 37.0.1",
+ "sp-core 34.0.0",
+ "sp-runtime 39.0.2",
 ]
 
 [[package]]
@@ -10349,7 +13051,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8fe06b03b8a291c09507c42f92a2c2c10dd3d62975d02c7f64a92d87bfe09b"
 dependencies = [
- "hyper",
+ "hyper 0.14.30",
  "log",
  "prometheus",
  "thiserror",
@@ -10363,23 +13065,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812076602836d6d90242c431729814c790c49685d142f47ec41f3b897a5fb6ad"
 dependencies = [
  "async-trait",
- "jsonrpsee",
+ "jsonrpsee 0.22.5",
  "log",
- "sc-rpc-api",
+ "sc-rpc-api 0.37.0",
  "serde",
- "sp-runtime",
+ "sp-runtime 35.0.0",
 ]
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "21.0.0"
+version = "24.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a7c3e61041eaa76a89ded469f84d243fb34557ba4ee1e60335e65c8b5540c9"
+checksum = "cf035ffe7335fb24053edfe4d0a5780250eda772082a1b80ae25835dd4c09265"
 dependencies = [
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
+ "jobserver",
  "parity-wasm",
  "polkavm-linker",
  "sp-maybe-compressed-blob",
@@ -10434,6 +13137,17 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -10709,6 +13423,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10786,6 +13515,7 @@ dependencies = [
  "futures-util",
  "pin-project",
  "pin-project-lite 0.2.14",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -10801,9 +13531,25 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "http-range-header",
+ "pin-project-lite 0.2.14",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "pin-project-lite 0.2.14",
  "tower-layer",
  "tower-service",
@@ -10876,6 +13622,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10894,7 +13651,7 @@ dependencies = [
  "ansi_term",
  "chrono",
  "lazy_static",
- "matchers",
+ "matchers 0.0.1",
  "parking_lot 0.11.2",
  "regex",
  "serde",
@@ -10904,8 +13661,28 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.1.4",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers 0.1.0",
+ "nu-ansi-term",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "time",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
 ]
 
 [[package]]
@@ -10916,6 +13693,18 @@ checksum = "ff28e0f815c2fea41ebddf148e008b077d2faddb026c9555b29696114d602642"
 dependencies = [
  "hash-db",
  "hashbrown 0.13.2",
+ "log",
+ "rustc-hex",
+ "smallvec",
+]
+
+[[package]]
+name = "trie-db"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c992b4f40c234a074d48a757efeabb1a6be88af84c0c23f7ca158950cb0ae7f"
+dependencies = [
+ "hash-db",
  "log",
  "rustc-hex",
  "smallvec",
@@ -10939,7 +13728,7 @@ dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
  "data-encoding",
- "enum-as-inner",
+ "enum-as-inner 0.5.1",
  "futures-channel",
  "futures-io",
  "futures-util",
@@ -10949,6 +13738,31 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "socket2 0.4.10",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
+dependencies = [
+ "async-trait",
+ "cfg-if 1.0.0",
+ "data-encoding",
+ "enum-as-inner 0.6.1",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.5",
+ "smallvec",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -10973,7 +13787,28 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "trust-dns-proto",
+ "trust-dns-proto 0.22.0",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "futures-util",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "rand 0.8.5",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "trust-dns-proto 0.23.2",
 ]
 
 [[package]]
@@ -10991,29 +13826,29 @@ dependencies = [
  "async-trait",
  "clap",
  "frame-remote-externalities",
- "frame-try-runtime",
+ "frame-try-runtime 0.38.0",
  "hex",
  "log",
  "parity-scale-codec",
- "sc-cli",
- "sc-executor",
+ "sc-cli 0.40.0",
+ "sc-executor 0.36.0",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 30.0.0",
  "sp-consensus-aura",
- "sp-consensus-babe",
- "sp-core",
+ "sp-consensus-babe 0.36.0",
+ "sp-core 32.0.0",
  "sp-debug-derive",
- "sp-externalities",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-rpc",
- "sp-runtime",
- "sp-state-machine",
- "sp-timestamp",
- "sp-transaction-storage-proof",
- "sp-version",
+ "sp-externalities 0.28.0",
+ "sp-inherents 30.0.0",
+ "sp-io 34.0.0",
+ "sp-keystore 0.38.0",
+ "sp-rpc 30.0.0",
+ "sp-runtime 35.0.0",
+ "sp-state-machine 0.39.0",
+ "sp-timestamp 30.0.0",
+ "sp-transaction-storage-proof 30.0.0",
+ "sp-version 33.0.0",
  "sp-weights",
  "substrate-rpc-client",
  "zstd 0.12.4",
@@ -11024,6 +13859,26 @@ name = "tt-call"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f195fd851901624eee5a58c4bb2b4f06399148fcd0ed336e6f1cb60a9881df"
+
+[[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 0.2.12",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.21.12",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "twox-hash"
@@ -11131,6 +13986,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+dependencies = [
+ "bytes",
+ "tokio-util",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11152,6 +14017,12 @@ dependencies = [
  "idna 0.5.0",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
@@ -11199,7 +14070,7 @@ dependencies = [
  "constcat",
  "digest 0.10.7",
  "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
  "sha2 0.10.8",
  "sha3",
@@ -11603,6 +14474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11687,6 +14564,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -11960,16 +14852,65 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.5.2",
  "base64 0.13.1",
  "data-encoding",
- "der-parser",
+ "der-parser 8.2.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
+dependencies = [
+ "asn1-rs 0.5.2",
+ "data-encoding",
+ "der-parser 8.2.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.6.1",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "data-encoding",
+ "der-parser 9.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.7.1",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
 ]
 
 [[package]]
@@ -11982,6 +14923,21 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot 0.12.3",
+ "rand 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "yamux"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed0164ae619f2dc144909a9f082187ebb5893693d8c0196e8085283ccd4b776"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot 0.12.3",
+ "pin-project",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -12089,11 +15045,11 @@ dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
- "frame-support",
+ "frame-support 37.0.1",
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
- "frame-try-runtime",
+ "frame-try-runtime 0.43.0",
  "hp-verifiers",
  "log",
  "pallet-authorship",
@@ -12136,23 +15092,23 @@ dependencies = [
  "proof-of-existence-rpc-runtime-api",
  "scale-info",
  "serde_json",
- "sp-api",
- "sp-block-builder",
- "sp-consensus-babe",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-api 34.0.0",
+ "sp-block-builder 34.0.0",
+ "sp-consensus-babe 0.40.0",
+ "sp-consensus-grandpa 21.0.0",
+ "sp-core 34.0.0",
+ "sp-genesis-builder 0.15.1",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-staking",
+ "sp-offchain 34.0.0",
+ "sp-runtime 39.0.2",
+ "sp-session 35.0.0",
+ "sp-staking 34.0.0",
  "sp-std",
  "sp-storage",
- "sp-transaction-pool",
- "sp-version",
+ "sp-transaction-pool 34.0.0",
+ "sp-version 37.0.0",
  "sp-weights",
  "static_assertions",
  "substrate-wasm-builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ exclude = [
 [workspace.dependencies]
 clap = { version = "4.4.10", features = ["derive"] }
 futures = { version = "0.3.21", features = ["thread-pool"] }
-jsonrpsee = { version = "0.22.5", features = ["server"] }
+jsonrpsee = { version = "0.23.2", features = ["server"] }
 binary-merkle-tree = { default-features = false, version = "15.0.0" }
 snafu = { version = "0.8.0", default-features = false }
 async-trait = { version = "0.1.57" }
@@ -42,28 +42,28 @@ rstest = { version = "0.19.0" }
 rstest_reuse = { version = "0.7.0" }
 hex-literal = { version = "0.4.1" }
 
-sc-cli = { version = "0.40.0" }
-sc-executor = { version = "0.36.0" }
-sc-network = { version = "0.38.0" }
-sc-service = { version = "0.39.0" }
-sc-telemetry = { version = "18.0.0" }
-sc-transaction-pool = { version = "32.0.0" }
-sc-transaction-pool-api = { version = "32.0.0" }
-sc-offchain = { version = "33.0.0" }
-sc-consensus-babe = { version = "0.38.0" }
-sc-consensus-babe-rpc = { version = "0.38.0" }
-sc-consensus = { version = "0.37.0" }
-sc-consensus-grandpa = { version = "0.23.0" }
-sc-consensus-grandpa-rpc = { version = "0.23.0" }
-sc-client-api = { version = "32.0.0" }
-sc-sysinfo = { version = "31.0.0" }
+sc-cli = { version = "0.46.0" }
+sc-executor = { version = "0.40.0" }
+sc-network = { version = "0.44.0" }
+sc-service = { version = "0.45.0" }
+sc-telemetry = { version = "24.0.0" }
+sc-transaction-pool = { version = "37.0.0" }
+sc-transaction-pool-api = { version = "37.0.0" }
+sc-offchain = { version = "39.0.0" }
+sc-consensus-babe = { version = "0.44.0" }
+sc-consensus-babe-rpc = { version = "0.44.0" }
+sc-consensus = { version = "0.43.0" }
+sc-consensus-grandpa = { version = "0.29.0" }
+sc-consensus-grandpa-rpc = { version = "0.29.0" }
+sc-client-api = { version = "37.0.0" }
+sc-sysinfo = { version = "37.0.0" }
 
-pallet-transaction-payment = { default-features = false, version = "32.0.0" }
+pallet-transaction-payment = { default-features = false, version = "37.0.0" }
 
-sp-io = { default-features = false, version = "34.0.0" }
-sp-timestamp = { default-features = false, version = "30.0.0" }
-sp-keyring = { version = "35.0.0" }
-sp-keystore = { version = "0.38.0" }
+sp-io = { default-features = false, version = "38.0.0" }
+sp-timestamp = { default-features = false, version = "34.0.0" }
+sp-keyring = { version = "39.0.0" }
+sp-keystore = { version = "0.40.0" }
 
 native = { default-features = false, path = "native" }
 pallet-poe = { path = "pallets/proof_of_existence", default-features = false }
@@ -82,16 +82,16 @@ native-cache = { path = "utils/native-cache" }
 zkv-runtime = { path = "runtime", default-features = false }
 
 # These dependencies are used for the node template's RPCs
-sc-rpc = { version = "33.0.0" }
-sc-rpc-api = { version = "0.37.0" }
-sp-blockchain = { version = "32.0.0" }
-sc-basic-authorship = { version = "0.38.0" }
-substrate-frame-rpc-system = { version = "32.0.0" }
-frame-election-provider-support = { version = "32.0.0", default-features = false }
-pallet-election-provider-support-benchmarking = { version = "31.0.0", default-features = false }
-pallet-session-benchmarking = { version = "32.0.0", default-features = false }
-pallet-transaction-payment-rpc = { version = "34.0.0" }
-frame-benchmarking-cli = { version = "36.0.0" }
+sc-rpc = { version = "39.0.0" }
+sc-rpc-api = { version = "0.43.0" }
+sp-blockchain = { version = "37.0.0" }
+sc-basic-authorship = { version = "0.44.0" }
+substrate-frame-rpc-system = { version = "38.0.0" }
+frame-election-provider-support = { version = "37.0.0", default-features = false }
+pallet-election-provider-support-benchmarking = { version = "36.0.0", default-features = false }
+pallet-session-benchmarking = { version = "37.0.0", default-features = false }
+pallet-transaction-payment-rpc = { version = "40.0.0" }
+frame-benchmarking-cli = { version = "42.0.0" }
 
 # CLI-specific dependencies
 try-runtime-cli = { version = "0.42.0" }
@@ -104,78 +104,78 @@ scale-info = { version = "2.10.0", default-features = false, features = [
     "serde",
 ] }
 
-pallet-offences = { default-features = false, version = "31.0.0" }
-pallet-im-online = { default-features = false, version = "31.0.0" }
-pallet-authorship = { default-features = false, version = "32.0.0" }
-pallet-bags-list = { default-features = false, version = "31.0.0" }
-pallet-session = { default-features = false, version = "32.0.0" }
-pallet-staking = { default-features = false, version = "32.0.0" }
-pallet-staking-reward-curve = { default-features = false, version = "11.0.0" }
-pallet-babe = { default-features = false, version = "32.0.0" }
-pallet-balances = { default-features = false, version = "33.0.0" }
-frame-support = { default-features = false, version = "32.0.0" }
-pallet-grandpa = { default-features = false, version = "32.0.0" }
-pallet-sudo = { default-features = false, version = "32.0.0" }
-pallet-multisig = { default-features = false, version = "32.0.0" }
-pallet-scheduler = { default-features = false, version = "33.0.0" }
-pallet-preimage = { default-features = false, version = "32.0.0" }
-pallet-referenda = { default-features = false, version = "32.0.0" }
-pallet-utility = { default-features = false, version = "32.0.0" }
-pallet-vesting = { default-features = false, version = "32.0.0" }
-pallet-whitelist = { default-features = false, version = "31.0.0" }
-pallet-conviction-voting = { default-features = false, version = "32.0.0" }
-pallet-treasury = { default-features = false, version = "31.0.0" }
-pallet-bounties = { default-features = false, version = "31.0.0" }
-pallet-child-bounties = { default-features = false, version = "31.0.0" }
-pallet-proxy = { default-features = false, version = "32.0.0" }
-frame-system = { default-features = false, version = "32.0.0" }
-frame-try-runtime = { default-features = false, version = "0.38.0" }
-pallet-timestamp = { default-features = false, version = "31.0.0" }
-frame-executive = { default-features = false, version = "32.0.0" }
-sp-api = { default-features = false, version = "30.0.0" }
-sp-block-builder = { default-features = false, version = "30.0.0" }
-sp-consensus = { default-features = false, version = "0.36.0" }
+pallet-offences = { default-features = false, version = "36.0.0" }
+pallet-im-online = { default-features = false, version = "36.0.0" }
+pallet-authorship = { default-features = false, version = "37.0.0" }
+pallet-bags-list = { default-features = false, version = "36.0.0" }
+pallet-session = { default-features = false, version = "37.0.0" }
+pallet-staking = { default-features = false, version = "37.0.0" }
+pallet-staking-reward-curve = { default-features = false, version = "12.0.0" }
+pallet-babe = { default-features = false, version = "37.0.0" }
+pallet-balances = { default-features = false, version = "38.0.0" }
+frame-support = { default-features = false, version = "37.0.0" }
+pallet-grandpa = { default-features = false, version = "37.0.0" }
+pallet-sudo = { default-features = false, version = "37.0.0" }
+pallet-multisig = { default-features = false, version = "37.0.0" }
+pallet-scheduler = { default-features = false, version = "38.0.0" }
+pallet-preimage = { default-features = false, version = "37.0.0" }
+pallet-referenda = { default-features = false, version = "37.0.0" }
+pallet-utility = { default-features = false, version = "37.0.0" }
+pallet-vesting = { default-features = false, version = "37.0.0" }
+pallet-whitelist = { default-features = false, version = "36.0.0" }
+pallet-conviction-voting = { default-features = false, version = "37.0.0" }
+pallet-treasury = { default-features = false, version = "36.0.0" }
+pallet-bounties = { default-features = false, version = "36.0.0" }
+pallet-child-bounties = { default-features = false, version = "36.0.0" }
+pallet-proxy = { default-features = false, version = "37.0.0" }
+frame-system = { default-features = false, version = "37.0.0" }
+frame-try-runtime = { default-features = false, version = "0.43.0" }
+pallet-timestamp = { default-features = false, version = "36.0.0" }
+frame-executive = { default-features = false, version = "37.0.0" }
+sp-api = { default-features = false, version = "34.0.0" }
+sp-block-builder = { default-features = false, version = "34.0.0" }
+sp-consensus = { default-features = false, version = "0.40.0" }
 sp-consensus-babe = { default-features = false, features = [
     "serde",
-], version = "0.36.0" }
+], version = "0.40.0" }
 finality-grandpa = { default-features = false, version = "0.16.2" }
 sp-consensus-grandpa = { default-features = false, features = [
     "serde",
-], version = "17.0.0" }
-sp-core = { default-features = false, features = ["serde"], version = "32.0.0" }
-sp-inherents = { default-features = false, version = "30.0.0" }
-sp-offchain = { default-features = false, version = "30.0.0" }
+], version = "21.0.0" }
+sp-core = { default-features = false, features = ["serde"], version = "34.0.0" }
+sp-inherents = { default-features = false, version = "34.0.0" }
+sp-offchain = { default-features = false, version = "34.0.0" }
 sp-runtime = { default-features = false, features = [
     "serde",
-], version = "35.0.0" }
-sp-runtime-interface = { version = "27.0.0", default-features = false }
-sp-session = { default-features = false, version = "31.0.0" }
-sp-staking = { default-features = false, version = "30.0.0" }
+], version = "39.0.0" }
+sp-runtime-interface = { version = "28.0.0", default-features = false }
+sp-session = { default-features = false, version = "35.0.0" }
+sp-staking = { default-features = false, version = "34.0.0" }
 sp-std = { default-features = false, version = "14.0.0" }
 sp-storage = { default-features = false, version = "21.0.0" }
-sp-transaction-pool = { default-features = false, version = "30.0.0" }
+sp-transaction-pool = { default-features = false, version = "34.0.0" }
 sp-version = { default-features = false, features = [
     "serde",
-], version = "33.0.0" }
-serde_json = { version = "1.0.108", default-features = false, features = [
+], version = "37.0.0" }
+serde_json = { version = "1.0.114", default-features = false, features = [
     "alloc",
 ] }
 sp-weights = { default-features = false, version = "31.0.0" }
-sp-genesis-builder = { default-features = false, version = "0.11.0" }
-sp-npos-elections = { default-features = false, version = "30.0.0" }
+sp-genesis-builder = { default-features = false, version = "0.15.0" }
+sp-npos-elections = { default-features = false, version = "34.0.0" }
 hp-poe = { default-features = false, path = "primitives/hp-proof-of-existence" }
 proof-of-existence-rpc = { default-features = false, path = "rpc/proof_of_existence" }
 proof-of-existence-rpc-runtime-api = { default-features = false, path = "rpc/proof_of_existence/runtime-api" }
 
 # Used for the node template's RPCs
-frame-system-rpc-runtime-api = { default-features = false, version = "30.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = "32.0.0" }
+frame-system-rpc-runtime-api = { default-features = false, version = "34.0.0" }
+pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = "37.0.0" }
 
 # Used for runtime benchmarking
-frame-benchmarking = { default-features = false, version = "32.0.0" }
-frame-system-benchmarking = { default-features = false, version = "32.0.0" }
+frame-benchmarking = { default-features = false, version = "37.0.0" }
+frame-system-benchmarking = { default-features = false, version = "37.0.0" }
 
-substrate-wasm-builder = { version = "21.0.0" }
+substrate-wasm-builder = { version = "24.0.0" }
 substrate-build-script-utils = { version = "11.0.0" }
 
 [profile.release]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -118,7 +118,7 @@ pub fn authority_ids_from_ss58(
 pub fn development_config() -> Result<ChainSpec, String> {
     Ok(ChainSpec::builder(
         WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
-        Default::default(),
+        None,
     )
     .with_name("Development")
     .with_id("dev")
@@ -153,7 +153,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
 pub fn local_config() -> Result<ChainSpec, String> {
     Ok(ChainSpec::builder(
         WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
-        Default::default(),
+        None,
     )
     .with_name("ZKV Local")
     .with_id("zkv_local")
@@ -194,7 +194,7 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
 pub fn testnet_config_build() -> Result<ChainSpec, String> {
     Ok(ChainSpec::builder(
         WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
-        Default::default(),
+        None,
     )
     .with_name("ZKV Testnet")
     .with_id("zkv_testnet")

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -21,7 +21,7 @@ use sp_consensus_grandpa::AuthorityId as GrandpaId;
 use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use zkv_runtime::currency::{Balance, ACME};
-use zkv_runtime::{currency, AccountId, RuntimeGenesisConfig, SessionKeys, Signature, WASM_BINARY};
+use zkv_runtime::{currency, AccountId, SessionKeys, Signature, WASM_BINARY};
 
 // The connection strings for bootnodes
 const BOOTNODE_1_DNS: &str = "bootnode-tn-1.zkverify.io";
@@ -33,7 +33,8 @@ const BOOTNODE_2_PEER_ID: &str = "12D3KooWEjVadU1YWyfDGvyRXPbCq2rXhzJtXaG4RxJZBk
 const STAGING_TELEMETRY_URL: &str = "wss://testnet-telemetry.zkverify.io/submit/";
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
-pub type ChainSpec = sc_service::GenericChainSpec<RuntimeGenesisConfig>;
+type Extensions = Option<()>;
+pub type ChainSpec = sc_service::GenericChainSpec<Extensions>;
 
 const ENDOWMENT: Balance = 1_000_000 * ACME;
 const STASH_BOND: Balance = ENDOWMENT / 100;
@@ -117,7 +118,7 @@ pub fn authority_ids_from_ss58(
 pub fn development_config() -> Result<ChainSpec, String> {
     Ok(ChainSpec::builder(
         WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
-        None,
+        Default::default(),
     )
     .with_name("Development")
     .with_id("dev")
@@ -152,7 +153,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
 pub fn local_config() -> Result<ChainSpec, String> {
     Ok(ChainSpec::builder(
         WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
-        None,
+        Default::default(),
     )
     .with_name("ZKV Local")
     .with_id("zkv_local")
@@ -193,7 +194,7 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
 pub fn testnet_config_build() -> Result<ChainSpec, String> {
     Ok(ChainSpec::builder(
         WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
-        None,
+        Default::default(),
     )
     .with_name("ZKV Testnet")
     .with_id("zkv_testnet")

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -185,8 +185,8 @@ pub fn run() -> sc_cli::Result<()> {
                             );
                         }
 
-                        cmd.run::<sp_runtime::traits::HashingFor<Block>, HLNativeHostFunctions>(
-                            config,
+                        cmd.run_with_spec::<sp_runtime::traits::HashingFor<Block>, HLNativeHostFunctions>(
+                            Some(config.chain_spec),
                         )
                     }
                     BenchmarkCmd::Block(cmd) => {
@@ -257,7 +257,8 @@ pub fn run() -> sc_cli::Result<()> {
             ));
 
             runner.run_node_until_exit(|config| async move {
-                service::new_full(config).map_err(sc_cli::Error::Service)
+                service::new_full::<sc_network::NetworkWorker<_, _>>(config)
+                    .map_err(sc_cli::Error::Service)
             })
         }
     }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -18,9 +18,11 @@
 use futures::FutureExt;
 use sc_client_api::{Backend, BlockBackend};
 use sc_consensus_babe::{BabeBlockImport, SlotProportion};
+use sc_network::NotificationMetrics;
 use sc_service::{error::Error as ServiceError, Configuration, TaskManager, WarpSyncParams};
 use sc_telemetry::{Telemetry, TelemetryWorker};
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
+use sp_api::__private::BlockT;
 use std::{sync::Arc, time::Duration};
 use zkv_runtime::{self, opaque::Block, RuntimeApi};
 
@@ -167,7 +169,9 @@ pub fn new_partial(
 }
 
 /// Builds a new service for a full client.
-pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
+pub fn new_full<Network: sc_network::NetworkBackend<Block, <Block as BlockT>::Hash>>(
+    config: Configuration,
+) -> Result<TaskManager, ServiceError> {
     let sc_service::PartialComponents {
         client,
         backend,
@@ -179,7 +183,9 @@ pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
         other: (block_import, grandpa_link, babe_link, babe_worker_handle, mut telemetry),
     } = new_partial(&config)?;
 
-    let mut net_config = sc_network::config::FullNetworkConfiguration::new(&config.network);
+    let mut net_config =
+        sc_network::config::FullNetworkConfiguration::<_, _, Network>::new(&config.network);
+    let peer_store_handle = net_config.peer_store_handle();
 
     let grandpa_protocol_name = sc_consensus_grandpa::protocol_standard_name(
         &client
@@ -190,7 +196,11 @@ pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
         &config.chain_spec,
     );
     let (grandpa_protocol_config, grandpa_notification_service) =
-        sc_consensus_grandpa::grandpa_peers_set_config(grandpa_protocol_name.clone());
+        sc_consensus_grandpa::grandpa_peers_set_config::<_, Network>(
+            grandpa_protocol_name.clone(),
+            NotificationMetrics::new(None),
+            peer_store_handle,
+        );
     net_config.add_notification_protocol(grandpa_protocol_config);
 
     let warp_sync = Arc::new(sc_consensus_grandpa::warp_proof::NetworkProvider::new(
@@ -210,6 +220,7 @@ pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
             block_announce_validator_builder: None,
             warp_sync_params: Some(WarpSyncParams::WithProvider(warp_sync)),
             block_relay: None,
+            metrics: NotificationMetrics::new(None),
         })?;
 
     if config.offchain_worker.enabled {
@@ -224,7 +235,7 @@ pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
                 transaction_pool: Some(OffchainTransactionPoolFactory::new(
                     transaction_pool.clone(),
                 )),
-                network_provider: network.clone(),
+                network_provider: Arc::new(network.clone()),
                 enable_http_requests: true,
                 custom_extensions: |_| vec![],
             })

--- a/pallets/proof_of_existence/src/tests.rs
+++ b/pallets/proof_of_existence/src/tests.rs
@@ -225,6 +225,7 @@ mod should_inherent_call {
 
     mod publish_attestation {
         use super::*;
+        use frame_support::traits::Time;
 
         #[test]
         fn if_enough_leaves() {
@@ -259,6 +260,7 @@ mod should_inherent_call {
 
     mod not_publish_attestation {
         use super::*;
+        use frame_support::traits::Time;
 
         #[test]
         fn if_not_enough_leaves() {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -499,7 +499,7 @@ impl pallet_bounties::Config for Runtime {
     type DataDepositPerByte = DataDepositPerByte;
     type MaximumReasonLength = MaximumReasonLength;
     type WeightInfo = weights::pallet_bounties::ZKVWeight<Runtime>;
-    type OnSlash = ();
+    type OnSlash = Treasury;
 }
 
 parameter_types! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -73,7 +73,7 @@ use static_assertions::const_assert;
 use weights::block_weights::BlockExecutionWeight;
 use weights::extrinsic_weights::ExtrinsicBaseWeight;
 
-use pallet_transaction_payment::{ConstFeeMultiplier, CurrencyAdapter, Multiplier};
+use pallet_transaction_payment::{ConstFeeMultiplier, FungibleAdapter, Multiplier};
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
@@ -369,7 +369,7 @@ impl_opaque_keys! {
 
 impl pallet_transaction_payment::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type OnChargeTransaction = CurrencyAdapter<Balances, ()>;
+    type OnChargeTransaction = FungibleAdapter<Balances, ()>;
     type OperationalFeeMultiplier = ConstU8<5>;
     type WeightToFee = IdentityFee<Balance>;
     type LengthToFee = IdentityFee<Balance>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -47,7 +47,7 @@ use frame_election_provider_support::{
     onchain::OnChainExecution,
     SequentialPhragmen,
 };
-use frame_support::genesis_builder_helper::{build_config, create_default_config};
+use frame_support::genesis_builder_helper::{build_state, get_preset};
 
 pub use frame_support::{
     construct_runtime, derive_impl,
@@ -456,13 +456,8 @@ parameter_types! {
 impl pallet_treasury::Config for Runtime {
     type PalletId = TreasuryPalletId;
     type Currency = Balances;
-    type ApproveOrigin = EitherOfDiverse<EnsureRoot<AccountId>, Treasurer>;
     type RejectOrigin = EitherOfDiverse<EnsureRoot<AccountId>, Treasurer>;
     type RuntimeEvent = RuntimeEvent;
-    type OnSlash = Treasury;
-    type ProposalBond = ProposalBond;
-    type ProposalBondMinimum = ProposalBondMinimum;
-    type ProposalBondMaximum = ProposalBondMaximum;
     type SpendPeriod = SpendPeriod;
     type Burn = Burn;
     type BurnDestination = ();
@@ -504,6 +499,7 @@ impl pallet_bounties::Config for Runtime {
     type DataDepositPerByte = DataDepositPerByte;
     type MaximumReasonLength = MaximumReasonLength;
     type WeightInfo = weights::pallet_bounties::ZKVWeight<Runtime>;
+    type OnSlash = ();
 }
 
 parameter_types! {
@@ -567,7 +563,6 @@ parameter_types! {
                                                          // remains locked
     pub const SlashDeferDuration: sp_staking::EraIndex = 0; // eras to wait before slashing is
                                                             // applied
-    pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
     pub HistoryDepth: u32 = 30; // Number of eras to keep in history. Older eras cannot be claimed.
 }
 
@@ -621,7 +616,6 @@ impl pallet_staking::Config for Runtime {
     type SessionInterface = Self;
     type EraPayout = payout::ZKVPayout;
     type NextNewSession = Session;
-    type OffendingValidatorsThreshold = OffendingValidatorsThreshold; // Exceeding this threshold would force a new era
     type ElectionProvider = OnChainExecution<OnChainSeqPhragmen>;
     type GenesisElectionProvider = OnChainExecution<OnChainSeqPhragmen>;
     type VoterList = VoterList;
@@ -635,6 +629,7 @@ impl pallet_staking::Config for Runtime {
     type MaxExposurePageSize = ConstU32<64>;
     type MaxControllersInDeprecationBatch = ConstU32<1>; // We do not have any controller accounts
                                                          // but we need at least 1 for benchmarks
+    type DisablingStrategy = pallet_staking::UpToLimitDisablingStrategy;
 }
 
 impl pallet_authorship::Config for Runtime {
@@ -1233,12 +1228,16 @@ impl_runtime_apis! {
     }
 
     impl sp_genesis_builder::GenesisBuilder<Block> for Runtime {
-        fn create_default_config() -> Vec<u8> {
-            create_default_config::<RuntimeGenesisConfig>()
-        }
+        fn build_state(config: Vec<u8>) -> sp_genesis_builder::Result {
+			build_state::<RuntimeGenesisConfig>(config)
+		}
 
-        fn build_config(config: Vec<u8>) -> sp_genesis_builder::Result {
-            build_config::<RuntimeGenesisConfig>(config)
-        }
+		fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
+			get_preset::<RuntimeGenesisConfig>(id, |_| None)
+		}
+
+		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
+			vec![]
+		}
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1229,15 +1229,15 @@ impl_runtime_apis! {
 
     impl sp_genesis_builder::GenesisBuilder<Block> for Runtime {
         fn build_state(config: Vec<u8>) -> sp_genesis_builder::Result {
-			build_state::<RuntimeGenesisConfig>(config)
-		}
+            build_state::<RuntimeGenesisConfig>(config)
+        }
 
-		fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
-			get_preset::<RuntimeGenesisConfig>(id, |_| None)
-		}
+        fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
+            get_preset::<RuntimeGenesisConfig>(id, |_| None)
+        }
 
-		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
-			vec![]
-		}
+        fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
+            vec![]
+        }
     }
 }

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -1181,7 +1181,7 @@ mod pallets_interact {
 
     mod staking {
         use super::*;
-        use sp_staking::offence::{DisableStrategy, OffenceDetails};
+        use sp_staking::offence::OffenceDetails;
 
         #[test]
         fn slashes_go_to_treasury() {
@@ -1210,7 +1210,6 @@ mod pallets_interact {
                     }],
                     &[Perbill::from_percent(100)],
                     0,
-                    DisableStrategy::WhenSlashed,
                 );
 
                 // Check that treasury balance increased

--- a/runtime/src/weights/pallet_balances.rs
+++ b/runtime/src/weights/pallet_balances.rs
@@ -155,4 +155,20 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for ZKVWeight<T> {
         // Minimum execution time: 4_439_000 picoseconds.
         Weight::from_parts(4_839_000, 0)
     }
+    fn burn_allow_death() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `0`
+        //  Estimated: `0`
+        // Minimum execution time: 27_328_000 picoseconds.
+        Weight::from_parts(27_785_000, 0)
+            .saturating_add(Weight::from_parts(0, 0))
+    }
+    fn burn_keep_alive() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `0`
+        //  Estimated: `0`
+        // Minimum execution time: 17_797_000 picoseconds.
+        Weight::from_parts(18_103_000, 0)
+            .saturating_add(Weight::from_parts(0, 0))
+    }
 }

--- a/runtime/src/weights/pallet_treasury.rs
+++ b/runtime/src/weights/pallet_treasury.rs
@@ -42,51 +42,6 @@ impl<T: frame_system::Config> pallet_treasury::WeightInfo for ZKVWeight<T> {
             .saturating_add(T::DbWeight::get().reads(2))
             .saturating_add(T::DbWeight::get().writes(3))
     }
-    /// Storage: Treasury ProposalCount (r:1 w:1)
-    /// Proof: Treasury ProposalCount (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
-    /// Storage: Treasury Proposals (r:0 w:1)
-    /// Proof: Treasury Proposals (max_values: None, max_size: Some(108), added: 2583, mode: MaxEncodedLen)
-    fn propose_spend() -> Weight {
-        // Proof Size summary in bytes:
-        //  Measured:  `143`
-        //  Estimated: `1489`
-        // Minimum execution time: 354_000_000 picoseconds.
-        Weight::from_parts(376_000_000, 0)
-            .saturating_add(Weight::from_parts(0, 1489))
-            .saturating_add(T::DbWeight::get().reads(1))
-            .saturating_add(T::DbWeight::get().writes(2))
-    }
-    /// Storage: Treasury Proposals (r:1 w:1)
-    /// Proof: Treasury Proposals (max_values: None, max_size: Some(108), added: 2583, mode: MaxEncodedLen)
-    /// Storage: System Account (r:1 w:1)
-    /// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
-    fn reject_proposal() -> Weight {
-        // Proof Size summary in bytes:
-        //  Measured:  `301`
-        //  Estimated: `3593`
-        // Minimum execution time: 547_000_000 picoseconds.
-        Weight::from_parts(550_000_000, 0)
-            .saturating_add(Weight::from_parts(0, 3593))
-            .saturating_add(T::DbWeight::get().reads(2))
-            .saturating_add(T::DbWeight::get().writes(2))
-    }
-    /// Storage: Treasury Proposals (r:1 w:0)
-    /// Proof: Treasury Proposals (max_values: None, max_size: Some(108), added: 2583, mode: MaxEncodedLen)
-    /// Storage: Treasury Approvals (r:1 w:1)
-    /// Proof: Treasury Approvals (max_values: Some(1), max_size: Some(402), added: 897, mode: MaxEncodedLen)
-    /// The range of component `p` is `[0, 99]`.
-    fn approve_proposal(p: u32, ) -> Weight {
-        // Proof Size summary in bytes:
-        //  Measured:  `470 + p * (8 ±0)`
-        //  Estimated: `3573`
-        // Minimum execution time: 104_000_000 picoseconds.
-        Weight::from_parts(121_184_402, 0)
-            .saturating_add(Weight::from_parts(0, 3573))
-            // Standard Error: 42_854
-            .saturating_add(Weight::from_parts(153_112, 0).saturating_mul(p.into()))
-            .saturating_add(T::DbWeight::get().reads(2))
-            .saturating_add(T::DbWeight::get().writes(1))
-    }
     /// Storage: Treasury Approvals (r:1 w:1)
     /// Proof: Treasury Approvals (max_values: Some(1), max_size: Some(402), added: 897, mode: MaxEncodedLen)
     fn remove_approval() -> Weight {

--- a/zombienet-tests/0001-simple_test.zndsl
+++ b/zombienet-tests/0001-simple_test.zndsl
@@ -13,5 +13,5 @@ alice: reports node_roles is 4
 alice: reports sub_libp2p_is_major_syncing is 0
 
 # logs
-bob: log line matches glob "*rted #1*" within 10 seconds
-bob: log line matches "Imported #[0-9]+" within 10 seconds
+bob: log line matches glob "*rted #*" within 10 seconds
+bob: log line matches "Imported #" within 10 seconds


### PR DESCRIPTION
**Pallet treasury**
remove _ApproveOrigin_ -> Found this comment on this type before it was effectively removed  https://github.com/paritytech/polkadot-sdk/pull/4831/files
// The creation of proposals via the treasury pallet is deprecated and should not be utilized.
 	// Instead, public or fellowship referenda should be used to propose and command the treasury
 	// spend or spend_local dispatchables. The parameters below have been configured accordingly to
 	// discourage its use.
Remove _OnSlash_-> This was added to the bounty pallets instead (PR comment in https://github.com/paritytech/polkadot-sdk/pull/4831)
Remove _ProposalBond_ _ProposalBondMinimum_ and _ProposalBondMaximum_ -> https://github.com/paritytech/polkadot-sdk/pull/3820/commits/3d26a9235d84fb3b353ac537e4c1b49d482581a1 I feel this is because they all related to proposal and based on the first point. proposals are not done via the treasury pallet anymore which is why these types are useless now

**Pallet bounties**
Added _OnSlash_ as specified before, coming from treasury

**Pallet staking**
Replace _OffendingValidatorsThreshold_ with _DisablingStrategy_ https://github.com/paritytech/polkadot-sdk/pull/2226

**node**
remove deprecated _RuntimeGenesisConfig_ : https://github.com/paritytech/polkadot-sdk/pull/4410


**TODO** Re run benchmark for **pallet_balances**