### PR TITLE
Enable to share the same native cache  on different source base

### DIFF
--- a/utils/native-cache/src/config.rs
+++ b/utils/native-cache/src/config.rs
@@ -38,7 +38,13 @@ impl Config {
         })
     }
 
-    fn envs(&mut self) -> &mut Table {
+    fn envs(&self) -> Option<&Table> {
+        self.body
+            .get("env")
+            .map(|e| e.as_table().expect("[env] if exists should be a table"))
+    }
+
+    fn envs_mut(&mut self) -> &mut Table {
         self.body
             .entry("env")
             .or_insert_with(|| {
@@ -50,9 +56,9 @@ impl Config {
             .expect("[env] if exists should be a table")
     }
 
-    fn inner_add(envs: &mut Table, dependency: &impl Dependency) -> bool {
+    fn inner_add(envs: &mut Table, dependency: &impl Dependency, value: impl AsRef<str>) -> bool {
         let k = dependency.env_key().to_owned();
-        let v: Value = dependency.env_value().into();
+        let v: Value = value.as_ref().to_owned().into();
 
         if Some(&v) != envs.get(&k) {
             log!("inserting envs value changed: {:?} -> {}", envs.get(&k), v);
@@ -79,14 +85,21 @@ impl Config {
     }
 
     /// Add a dependency to the cargo config.toml file.
-    pub fn add(&mut self, dependency: &impl Dependency) {
-        self.dirty |= Self::inner_add(self.envs(), dependency);
+    pub fn get(&self, dependency: &impl Dependency) -> Option<String> {
+        self.envs()
+            .and_then(|envs| envs.get(dependency.env_key()))
+            .map(ToString::to_string)
+    }
+
+    /// Add a dependency to the cargo config.toml file.
+    pub fn add(&mut self, dependency: &impl Dependency, value: impl AsRef<str>) {
+        self.dirty |= Self::inner_add(self.envs_mut(), dependency, value);
     }
 
     /// Remove a dependency to the cargo config.toml file.
     pub fn remove(&mut self, dependency: &impl Dependency) {
         let old = self.dirty;
-        self.dirty |= self.envs().remove(dependency.env_key()).is_some();
+        self.dirty |= self.envs_mut().remove(dependency.env_key()).is_some();
         if self.dirty != old {
             log!("Removed env: {}", dependency.env_key());
         }

--- a/utils/native-cache/src/config.rs
+++ b/utils/native-cache/src/config.rs
@@ -84,7 +84,7 @@ impl Config {
         Ok(())
     }
 
-    /// Add a dependency to the cargo config.toml file.
+    /// Get dependency configuration from the cargo config.toml file.
     pub fn get(&self, dependency: &impl Dependency) -> Option<String> {
         self.envs()
             .and_then(|envs| envs.get(dependency.env_key()))

--- a/utils/native-cache/src/dependency.rs
+++ b/utils/native-cache/src/dependency.rs
@@ -3,49 +3,43 @@ use std::path::Path;
 /// The trait that define how to cache a dependency.
 pub trait Dependency {
     /// The path where to cache the dependency files.
-    fn cache_path(&self) -> &Path;
+    fn default_cache_path(&self) -> &Path;
     /// The environment key value.
     fn env_key(&self) -> &str;
-    /// The environment value.
-    fn env_value(&self) -> String;
     /// Check if the cache folder is still valid.
-    fn is_valid_cache(&self) -> bool;
+    fn is_valid_cache(&self, cache: &Path) -> bool;
     /// Return true if the given `path`` is a valid source folder for the dependency.
     fn folder_match(&self, path: &Path) -> bool;
     /// Cache the dependency files in the `source` folder .
-    fn cache_files(&self, source: &Path) -> Result<(), std::io::Error>;
+    fn cache_files(&self, source: &Path, dest: &Path) -> Result<(), std::io::Error>;
     /// Emit the rerun rules for this dependency
-    fn rerun_if(&self);
+    fn rerun_if(&self, cache: &Path);
 }
 
 /// Blanket implementation for `Box<dyn Dependency>`
 impl<T: Dependency + ?Sized> Dependency for Box<T> {
-    fn cache_path(&self) -> &Path {
-        self.as_ref().cache_path()
+    fn default_cache_path(&self) -> &Path {
+        self.as_ref().default_cache_path()
     }
 
     fn env_key(&self) -> &str {
         self.as_ref().env_key()
     }
 
-    fn env_value(&self) -> String {
-        self.as_ref().env_value()
-    }
-
-    fn is_valid_cache(&self) -> bool {
-        self.as_ref().is_valid_cache()
+    fn is_valid_cache(&self, cache: &Path) -> bool {
+        self.as_ref().is_valid_cache(cache)
     }
 
     fn folder_match(&self, path: &Path) -> bool {
         self.as_ref().folder_match(path)
     }
 
-    fn cache_files(&self, source: &Path) -> Result<(), std::io::Error> {
-        self.as_ref().cache_files(source)
+    fn cache_files(&self, source: &Path, dest: &Path) -> Result<(), std::io::Error> {
+        self.as_ref().cache_files(source, dest)
     }
 
-    fn rerun_if(&self) {
-        self.as_ref().rerun_if()
+    fn rerun_if(&self, cache: &Path) {
+        self.as_ref().rerun_if(cache)
     }
 }
 

--- a/utils/native-cache/src/lib.rs
+++ b/utils/native-cache/src/lib.rs
@@ -79,13 +79,13 @@ fn handle_dependency_inner(
     }
 
     let cache = dependency.default_cache_path();
-    let valid = if dependency.is_valid_cache(&cache) {
+    let valid = if dependency.is_valid_cache(cache) {
         true
     } else {
         fill_cache(&target_path, cache, dependency)?
     };
     if valid {
-        dependency.rerun_if(&cache);
+        dependency.rerun_if(cache);
     } else {
         println!("cargo::rerun-if-changed={}", target_path.display());
     }

--- a/utils/native-cache/src/lib_dependency.rs
+++ b/utils/native-cache/src/lib_dependency.rs
@@ -118,7 +118,7 @@ impl<I: DependencyImpl> LibFilesDependency<I> {
 }
 
 impl<I: DependencyImpl> Dependency for LibFilesDependency<I> {
-    fn cache_path(&self) -> &Path {
+    fn default_cache_path(&self) -> &Path {
         &self.cache_path
     }
 
@@ -126,21 +126,11 @@ impl<I: DependencyImpl> Dependency for LibFilesDependency<I> {
         &self.env_key
     }
 
-    fn env_value(&self) -> String {
-        self.cache_path()
-            .canonicalize()
-            .expect("Should create absolute path")
-            .display()
-            .to_string()
-    }
-
-    fn is_valid_cache(&self) -> bool {
-        let cache = self.cache_path();
+    fn is_valid_cache(&self, cache: &Path) -> bool {
         fs::metadata(cache).is_ok() && self.is_valid_libs_folder(cache)
     }
 
-    fn cache_files(&self, source: &Path) -> Result<(), std::io::Error> {
-        let dest = self.cache_path();
+    fn cache_files(&self, source: &Path, dest: &Path) -> Result<(), std::io::Error> {
         fs::create_dir_all(dest)?;
         for entry in fs::read_dir(self.source_folder(source))? {
             let entry = entry?;
@@ -160,8 +150,8 @@ impl<I: DependencyImpl> Dependency for LibFilesDependency<I> {
             self.is_valid_source_folder(path))
     }
 
-    fn rerun_if(&self) {
-        println!("cargo::rerun-if-changed={}", self.cache_path().display());
+    fn rerun_if(&self, cache: &Path) {
+        println!("cargo::rerun-if-changed={}", cache.display());
         println!("cargo::rerun-if-env-changed={}", self.env_key());
     }
 }


### PR DESCRIPTION
The base idea is to check before if the cache pointed by the current env variable (if any) is valid.

If not we can create the new cache.