### PR TITLE
Some cache improvements

### DIFF
--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -29,24 +29,17 @@ jobs:
       - name: Set up deps cache
         run: mkdir deps
 
-      - name: Restore common cache
+      - name: Restore main cache
         if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
-        uses: actions/cache/restore@v3
+        uses: buildjet/cache/restore@v3
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            deps/
-          key: common-cache
-    
-      - name: Restore build cache
-        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
-        uses: actions/cache/restore@v3
-        with:
-          path: |
             target/
+            deps/
           key: build-cache
 
       - name: Set docker env vars
@@ -63,22 +56,15 @@ jobs:
       - name: Cargo build paratest node
         run: ${{ env.DOCKER_COMPOSE_CMD }} cargo build -p paratest-node --release
 
-      - name: Save common cache
+      - name: Save build cache
         if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_SAVE' }}
-        uses: actions/cache/save@v3
+        uses: buildjet/cache/save@v3
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            deps/
-          key: common-cache
-    
-      - name: Save build cache
-        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_SAVE' }}
-        uses: actions/cache/save@v3
-        with:
-          path: |
             target/
+            deps/
           key: build-cache

--- a/.github/workflows/CI-cache-manager.yml
+++ b/.github/workflows/CI-cache-manager.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Git checkout
+      - name: Init
         uses: actions/checkout@v4
 
-      - name: Clear caches
+      - name: Clear GH caches
         run: |
           sudo apt-get install gh
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
@@ -25,6 +25,18 @@ jobs:
             echo ${caches_list}
             gh cache delete --all
           fi
+      - name: Clear Buildjet Build # ALL These steps are slow (3 min due bug on buildjet action)
+        uses: buildjet/cache-delete@v1
+        with:
+          cache_key: "build-cache"
+      - name: Clear Buildjet Test
+        uses: buildjet/cache-delete@v1
+        with:
+          cache_key: "test-cache"
+      - name: Clear Buildjet Format
+        uses: buildjet/cache-delete@v1
+        with:
+          cache_key: "lint-format-cache"
 
   build-job:
     needs: [clear-caches-job]

--- a/.github/workflows/CI-coverage.yml
+++ b/.github/workflows/CI-coverage.yml
@@ -30,24 +30,17 @@ jobs:
       - name: Set up deps cache
         run: mkdir deps
 
-      - name: Restore common cache
+      - name: Restore coverage cache
         if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v3 # Use GH
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            deps/
-          key: common-cache
-    
-      - name: Restore coverage cache
-        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
-        uses: actions/cache/restore@v3
-        with:
-          path: |
             target/
+            deps/
           key: coverage-cache
 
       - name: Set docker env vars
@@ -68,10 +61,15 @@ jobs:
 
       - name: Save coverage cache
         if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_SAVE' }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v3 # Use GH
         with:
           path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
             target/
+            deps/
           key: coverage-cache
 
       - name: Upload output(s)

--- a/.github/workflows/CI-lint-format.yml
+++ b/.github/workflows/CI-lint-format.yml
@@ -28,24 +28,17 @@ jobs:
       - name: Set up deps cache
         run: mkdir deps
 
-      - name: Restore common cache
+      - name: Restore lint-format cache
         if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
-        uses: actions/cache/restore@v3
+        uses: buildjet/cache/restore@v3
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            deps/
-          key: common-cache
-    
-      - name: Restore lint-format cache
-        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
-        uses: actions/cache/restore@v3
-        with:
-          path: |
             target/
+            deps/
           key: lint-format-cache
 
       - name: Set docker env vars
@@ -61,12 +54,17 @@ jobs:
         shell: bash
         run: ${{ env.DOCKER_COMPOSE_CMD }} cargo fmt --check 2>&1 | tee formatting_output.txt
 
-      - name: Save lint-format-test cache
+      - name: Save lint-format cache
         if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_SAVE' }}
-        uses: actions/cache/save@v3
+        uses: buildjet/cache/save@v3
         with:
           path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
             target/
+            deps/
           key: lint-format-cache
 
       - name: Upload output(s)

--- a/.github/workflows/CI-manually-delete-buildjet-cache.yml
+++ b/.github/workflows/CI-manually-delete-buildjet-cache.yml
@@ -1,0 +1,19 @@
+name: Manually Delete BuildJet Cache
+on:
+  workflow_dispatch:
+    inputs:
+      cache_key:
+        description: 'BuildJet Cache Key to Delete'
+        required: true
+        type: string
+
+jobs:
+  manually-delete-buildjet-cache:
+    runs-on: ubuntu-latest
+    name: Delete Buildjet Cache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: buildjet/cache-delete@v1
+        with:
+          cache_key: ${{ inputs.cache_key }}

--- a/.github/workflows/CI-rustdoc.yml
+++ b/.github/workflows/CI-rustdoc.yml
@@ -28,17 +28,18 @@ jobs:
       - name: Set up deps cache
         run: mkdir deps
 
-      - name: Restore common cache
+      - name: Restore main cache
         if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
-        uses: actions/cache/restore@v3
+        uses: buildjet/cache/restore@v3
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
+            target/
             deps/
-          key: common-cache
+          key: build-cache
     
       - name: Set docker env vars
         run: |

--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -29,24 +29,17 @@ jobs:
       - name: Set up deps cache
         run: mkdir deps
 
-      - name: Restore common cache
+      - name: Restore test cache
         if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
-        uses: actions/cache/restore@v3
+        uses: buildjet/cache/restore@v3
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            deps/
-          key: common-cache
-    
-      - name: Restore test cache
-        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
-        uses: actions/cache/restore@v3
-        with:
-          path: |
             target/
+            deps/
           key: test-cache
 
       - name: Set docker env vars
@@ -66,24 +59,17 @@ jobs:
         shell: bash
         run: ${{ env.DOCKER_COMPOSE_CMD }} cargo test --test '*' --all-features --no-fail-fast --release 2>&1 | tee integration_tests_output.txt
 
-      - name: Save common cache
+      - name: Save test cache
         if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_SAVE' }}
-        uses: actions/cache/save@v3
+        uses: buildjet/cache/save@v3
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            deps/
-          key: common-cache
-    
-      - name: Save test cache
-        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_SAVE' }}
-        uses: actions/cache/save@v3
-        with:
-          path: |
             target/
+            deps/
           key: test-cache
 
       - name: Upload output(s)

--- a/.github/workflows/CI-zombienet-test.yml
+++ b/.github/workflows/CI-zombienet-test.yml
@@ -29,25 +29,18 @@ jobs:
       - name: Set up deps cache
         run: mkdir deps
 
-      - name: Restore common cache
+      - name: Restore main cache
         if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
-        uses: actions/cache/restore@v3
+        uses: buildjet/cache/restore@v3
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            deps/
-          key: common-cache
-    
-      - name: Restore zombienet-test cache
-        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
-        uses: actions/cache/restore@v3
-        with:
-          path: |
             target/
-          key: build-cache # same cache as "build" job (since "cargo build --release" is used in both jobs)
+            deps/
+          key: build-cache
 
       - name: Set docker env vars
         run: |

--- a/ci/entrypoint.sh
+++ b/ci/entrypoint.sh
@@ -99,6 +99,12 @@ fi
 chown -fR "$CURRENT_UID":"$CURRENT_GID" "${CARGO_HOME}" || fn_die "ERROR: Failed to change ownership of ${CARGO_HOME} directory. Exiting ..."
 chown -fR "$CURRENT_UID":"$CURRENT_GID" "${TARGET_DIR}" || fn_die "ERROR: Failed to  change ownership of ${DOCKER_BUILD_DIR}/target directory. Exiting ..."
 
+export DONT_CACHE_NATIVE="true"
+# On CI use CARGO_INCREMENTAL=1 is useless because the local source files are always newer
+# then the compiled artifact (cargo use timestamp to identify what to recompile). So we can
+# save 20/30% time on disable it without to lose any advantage.
+export CARGO_INCREMENTAL=0
+
 # Run
 if [ "$USERNAME" = "root" ]; then
   exec "$@"

--- a/utils/native-cache/src/lib.rs
+++ b/utils/native-cache/src/lib.rs
@@ -17,7 +17,7 @@
 //! [`handle_dependency`] and [`handle_dependencies`] functions.
 
 use std::{
-    fs,
+    env, fs,
     path::{Path, PathBuf},
 };
 
@@ -54,6 +54,9 @@ pub fn handle_dependency(
     dependency: &impl Dependency,
     profile: &str,
 ) -> anyhow::Result<()> {
+    if skip_native_cache() {
+        return Ok(());
+    }
     let target_path = target_path(target_root, profile);
     let valid = cache_dependency(&target_path, dependency)?;
     if valid {
@@ -74,6 +77,9 @@ pub fn handle_dependencies<'a>(
     dependencies: impl IntoIterator<Item = &'a Box<dyn Dependency>>,
     profile: &str,
 ) -> anyhow::Result<()> {
+    if skip_native_cache() {
+        return Ok(());
+    }
     for dependency in dependencies {
         handle_dependency(target_root.as_ref(), dependency, profile)?
     }
@@ -125,4 +131,11 @@ fn set_env_paths(dependency: &impl Dependency, reset: bool) -> anyhow::Result<()
         config.add(dependency);
     }
     config.store()
+}
+
+fn skip_native_cache() -> bool {
+    "true"
+        == &env::var("DONT_CACHE_NATIVE")
+            .unwrap_or_default()
+            .to_lowercase()
 }


### PR DESCRIPTION
1. 4 kind of chache that cache both registry and taget
2. moved all cache instead the codecoverage one on buildjet service that provide 20Gb free but a alimit on a single cache entry of 5Gb (covergare is more than 8)
3. Disabled `CARGO_INCREMENTAL` because is useless on CI 
4. Disable native cache because again are useless on CI

Little note about _3_. Cargo incremental is useful on develop machine because help on skip some partial artifacts compilation on local sources, but cargo use files timestamp to decide if should compile it or not and on CI all owned sorce files will have a timestamp older than the artifacts on the cache ones. Disabling the incremental build we can save 20/30 % in time

To test this PR I've run a cache manager step and then I'll run an orchestrator.

**ATTENTION**
Some notes about this caching strategy. We decided to use a _cache singleton_ because we want to leverage on job parallelism and our cache blobs are really huge and then all new cache element kick out the old ones really fast. **BUT** is not possible to share cache across different branches (reasonable) but we can only use cache generated from parent: that's means the cache created on main can only be used from the branch that are based after the `main/HEAD` tip at the time the cache is computed. To make it explicit imagine the you generate a new branch on Friday and  then a new PR was merged on main, the cache manager run on Sunday and if you try to execute the orchestrator on your new branch Monday you will not use any cache **till you rebase the branch on main**.

In order to mitigate the last described issue we can introduce a check that just check if the cache are present (in the orchestrator) and fail fast is some was missed with an explicit message that ask to rebase your branch on main (we can introduce a flag to override it if needed). In this case we should save money and time.... I hope.

**CACHE IS A MESS** 