### PR TITLE
Dimitris/bn254 integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-bn254-ext"
+version = "0.4.0"
+source = "git+https://github.com/zkVerify/accelerated-bn-cryptography.git#c764589d32d2460c41fb0fbee4c2012d1914e1f7"
+dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-models-ext",
+ "ark-std 0.4.0",
+]
+
+[[package]]
 name = "ark-crypto-primitives"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +462,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "itertools 0.10.5",
  "num-traits",
+ "rayon",
  "zeroize",
 ]
 
@@ -552,6 +565,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-models-ext"
+version = "0.4.0"
+source = "git+https://github.com/zkVerify/accelerated-bn-cryptography.git#c764589d32d2460c41fb0fbee4c2012d1914e1f7"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+]
+
+[[package]]
 name = "ark-poly"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +598,20 @@ dependencies = [
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
  "tracing",
+]
+
+[[package]]
+name = "ark-scale"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f69c00b3b529be29528a6f2fd5fa7b1790f8bed81b9cdca17e326538545a179"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "parity-scale-codec",
+ "scale-info",
 ]
 
 [[package]]
@@ -638,6 +677,7 @@ checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
+ "rayon",
 ]
 
 [[package]]
@@ -7370,6 +7410,11 @@ checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 name = "native"
 version = "0.3.0"
 dependencies = [
+ "ark-bn254",
+ "ark-bn254-ext",
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-scale",
  "bincode",
  "hp-groth16",
  "hp-verifiers",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -9,6 +9,10 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
+ark-bn254 = { version = "0.4.0", default-features = false }
+ark-bn254-ext = { git = "https://github.com/zkVerify/accelerated-bn-cryptography.git", default-features = false }
+ark-ec = { version = "0.4.0", default-features = false }
+ark-scale = { features = ["hazmat"], version = "0.0.12", default-features = false }
 zksync-era-verifier = { git = "https://github.com/HorizenLabs/zksync-era-verifier.git", tag = "v0.1.0", optional = true }
 zksync-era-verifier-deserialize = { git = "https://github.com/HorizenLabs/zksync-era-verifier.git", tag = "v0.1.0", optional = true }
 ultraplonk_verifier = { git = "https://github.com/HorizenLabs/ultraplonk_verifier.git", tag = "v0.2.0", optional = true }
@@ -24,9 +28,17 @@ hp-groth16 = { workspace = true }
 [build-dependencies]
 native-cache = { workspace = true, features = ["ultraplonk"] }
 
+[dev-dependencies]
+ark-ff = { version = "0.4.0", default-features = false }
+
 [features]
 default = ["std"]
 std = [
+    "ark-bn254/std",
+    "ark-bn254-ext/std",
+    "ark-ec/parallel",
+    "ark-ec/std",
+    "ark-scale/std",
     "hp-groth16/implementation",
     "sp-runtime-interface/std",
     "codec/std",

--- a/native/src/accelerated_bn/bn254.rs
+++ b/native/src/accelerated_bn/bn254.rs
@@ -1,0 +1,254 @@
+// Copyright 2024, Horizen Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! *BN254* types and host functions.
+
+use crate::accelerated_bn::utils;
+use ark_bn254_ext::CurveHooks;
+use ark_ec::{pairing::Pairing, CurveConfig};
+use sp_runtime_interface::runtime_interface;
+
+pub use ark_bn254_ext::{fq, fq::*, fq12, fq12::*, fq2, fq2::*, fq6, fq6::*, fr, fr::*};
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+/// First pairing group definitions.
+pub mod g1 {
+    /// Group configuration.
+    pub type Config = ark_bn254_ext::g1::Config<super::HostHooks>;
+    /// Short Weierstrass form point affine representation.
+    pub type G1Affine = ark_bn254_ext::g1::G1Affine<super::HostHooks>;
+    /// Short Weierstrass form point projective representation.
+    pub type G1Projective = ark_bn254_ext::g1::G1Projective<super::HostHooks>;
+}
+
+/// Second pairing group definitions.
+pub mod g2 {
+    /// Group configuration.
+    pub type Config = ark_bn254_ext::g2::Config<super::HostHooks>;
+    /// Short Weierstrass form point affine representation.
+    pub type G2Affine = ark_bn254_ext::g2::G2Affine<super::HostHooks>;
+    /// Short Weierstrass form point projective representation.
+    pub type G2Projective = ark_bn254_ext::g2::G2Projective<super::HostHooks>;
+}
+
+pub use self::{
+    g1::{Config as G1Config, G1Affine, G1Projective},
+    g2::{Config as G2Config, G2Affine, G2Projective},
+};
+
+/// Curve hooks jumping into [`host_calls`] host functions.
+#[derive(Copy, Clone)]
+pub struct HostHooks;
+
+/// Configuration for *BN254* curve.
+#[allow(dead_code)]
+pub type Config = ark_bn254_ext::Config<HostHooks>;
+
+/// *BN254* definition.
+///
+/// A generic *BN254* model specialized with *BN254* configuration.
+pub type Bn254 = ark_bn254_ext::Bn254<HostHooks>;
+
+impl CurveHooks for HostHooks {
+    fn bn254_multi_miller_loop(
+        g1: impl Iterator<Item = <Bn254 as Pairing>::G1Prepared>,
+        g2: impl Iterator<Item = <Bn254 as Pairing>::G2Prepared>,
+    ) -> Result<<Bn254 as Pairing>::TargetField, ()> {
+        let g1 = utils::encode(g1.collect::<Vec<_>>());
+        let g2 = utils::encode(g2.collect::<Vec<_>>());
+        let res =
+            host_calls::bn254_multi_miller_loop(g1.as_slice(), g2.as_slice()).unwrap_or_default();
+        utils::decode(res.as_slice()).map_err(|_| ())
+    }
+
+    fn bn254_final_exponentiation(
+        target: <Bn254 as Pairing>::TargetField,
+    ) -> Result<<Bn254 as Pairing>::TargetField, ()> {
+        let target = utils::encode(target);
+        let res = host_calls::bn254_final_exponentiation(target.as_slice()).unwrap_or_default();
+        utils::decode(res.as_slice()).map_err(|_| ())
+    }
+
+    fn bn254_msm_g1(
+        bases: &[G1Affine],
+        scalars: &[<G1Config as CurveConfig>::ScalarField],
+    ) -> Result<G1Projective, ()> {
+        let bases = utils::encode(bases);
+        let scalars = utils::encode(scalars);
+        let res =
+            host_calls::bn254_msm_g1(bases.as_slice(), scalars.as_slice()).unwrap_or_default();
+        utils::decode_proj_sw(res.as_slice()).map_err(|_| ())
+    }
+
+    fn bn254_msm_g2(
+        bases: &[G2Affine],
+        scalars: &[<G2Config as CurveConfig>::ScalarField],
+    ) -> Result<G2Projective, ()> {
+        let bases = utils::encode(bases);
+        let scalars = utils::encode(scalars);
+        let res =
+            host_calls::bn254_msm_g2(bases.as_slice(), scalars.as_slice()).unwrap_or_default();
+        utils::decode_proj_sw(res.as_slice()).map_err(|_| ())
+    }
+
+    fn bn254_mul_projective_g1(base: &G1Projective, scalar: &[u64]) -> Result<G1Projective, ()> {
+        let base = utils::encode_proj_sw(base);
+        let scalar = utils::encode(scalar);
+        let res = host_calls::bn254_mul_projective_g1(base.as_slice(), scalar.as_slice())
+            .unwrap_or_default();
+        utils::decode_proj_sw(res.as_slice()).map_err(|_| ())
+    }
+
+    fn bn254_mul_projective_g2(base: &G2Projective, scalar: &[u64]) -> Result<G2Projective, ()> {
+        let base = utils::encode_proj_sw(base);
+        let scalar = utils::encode(scalar);
+        let res = host_calls::bn254_mul_projective_g2(base.as_slice(), scalar.as_slice())
+            .unwrap_or_default();
+        utils::decode_proj_sw(res.as_slice()).map_err(|_| ())
+    }
+}
+
+/// Interfaces for working with *Arkworks* *BN254* elliptic curve related types
+/// from within the runtime.
+///
+/// All types are (de-)serialized through the wrapper types from the `ark-scale` trait,
+/// with `ark_scale::{ArkScale, ArkScaleProjective}`.
+///
+/// `ArkScale`'s `Usage` generic parameter is expected to be set to "not-validated"
+/// and "not-compressed".
+#[runtime_interface]
+pub trait HostCalls {
+    /// Pairing multi Miller loop for *BN254*.
+    ///
+    /// - Receives encoded:
+    ///   - `a`: `ArkScale<Vec<G1Affine>>`.
+    ///   - `b`: `ArkScale<Vec<G2Affine>>`.
+    /// - Returns encoded:  `ArkScale<Bn254::TargetField>`.
+    #[allow(clippy::result_unit_err)]
+    fn bn254_multi_miller_loop(a: &[u8], b: &[u8]) -> Result<Vec<u8>, ()> {
+        utils::native::multi_miller_loop::<ark_bn254::Bn254>(a, b)
+    }
+
+    /// Pairing final exponentiation for *BN254*.
+    ///
+    /// - Receives encoded: `ArkScale<Bn254::TargetField>`.
+    /// - Returns encoded:  `ArkScale<Bn254::TargetField>`.
+    #[allow(clippy::result_unit_err)]
+    fn bn254_final_exponentiation(f: &[u8]) -> Result<Vec<u8>, ()> {
+        utils::native::final_exponentiation::<ark_bn254::Bn254>(f)
+    }
+
+    /// Multi scalar multiplication on *G1* for *BN254*.
+    ///
+    /// - Receives encoded:
+    ///   - `bases`: `ArkScale<Vec<G1Affine>>`.
+    ///   - `scalars`: `ArkScale<Vec<G1Config::ScalarField>>`.
+    /// - Returns encoded: `ArkScaleProjective<G1Projective>`.
+    #[allow(clippy::result_unit_err)]
+    fn bn254_msm_g1(bases: &[u8], scalars: &[u8]) -> Result<Vec<u8>, ()> {
+        utils::native::msm_sw::<ark_bn254::g1::Config>(bases, scalars)
+    }
+
+    /// Multi scalar multiplication on *G2* for *BN254*.
+    ///
+    /// - Receives encoded:
+    ///   - `bases`: `ArkScale<Vec<G2Affine>>`.
+    ///   - `scalars`: `ArkScale<Vec<G2Config::ScalarField>>`.
+    /// - Returns encoded: `ArkScaleProjective<G2Projective>`.
+    #[allow(clippy::result_unit_err)]
+    fn bn254_msm_g2(bases: &[u8], scalars: &[u8]) -> Result<Vec<u8>, ()> {
+        utils::native::msm_sw::<ark_bn254::g2::Config>(bases, scalars)
+    }
+
+    /// Projective multiplication on *G1* for *BN254*.
+    ///
+    /// - Receives encoded:
+    ///   - `base`: `ArkScaleProjective<G1Projective>`.
+    ///   - `scalar`: `ArkScale<Vec<u64>>`.
+    /// - Returns encoded: `ArkScaleProjective<G1Projective>`.
+    #[allow(clippy::result_unit_err)]
+    fn bn254_mul_projective_g1(base: &[u8], scalar: &[u8]) -> Result<Vec<u8>, ()> {
+        utils::native::mul_projective_sw::<ark_bn254::g1::Config>(base, scalar)
+    }
+
+    /// Projective multiplication on *G2* for *BN254*.
+    ///
+    /// - Receives encoded:
+    ///   - `base`: `ArkScaleProjective<G2Projective>`.
+    ///   - `scalar`: `ArkScale<Vec<u64>>`.
+    /// - Returns encoded: `ArkScaleProjective<ark_bn254::G2Projective>`.
+    #[allow(clippy::result_unit_err)]
+    fn bn254_mul_projective_g2(base: &[u8], scalar: &[u8]) -> Result<Vec<u8>, ()> {
+        utils::native::mul_projective_sw::<ark_bn254::g2::Config>(base, scalar)
+    }
+}
+
+#[cfg(test)]
+mod check_against_arkworks {
+    use crate::accelerated_bn::test_utils::*;
+    use crate::bn254;
+
+    #[test]
+    pub fn pairing() {
+        assert_eq!(
+            multi_pairing::<bn254::Bn254>(),
+            multi_pairing::<ark_bn254::Bn254>()
+        );
+    }
+
+    #[test]
+    pub fn msm_g1() {
+        assert_eq!(msm::<bn254::g1::Config>(), msm::<ark_bn254::g1::Config>());
+    }
+
+    #[test]
+    pub fn msm_g2() {
+        assert_eq!(msm::<bn254::g2::Config>(), msm::<ark_bn254::g2::Config>());
+    }
+
+    #[test]
+    pub fn mul_projective_g1() {
+        assert_eq!(
+            mul_projective::<bn254::g1::Config>(),
+            mul_projective::<ark_bn254::g1::Config>()
+        );
+    }
+
+    #[test]
+    pub fn mul_projective_g2() {
+        assert_eq!(
+            mul_projective::<bn254::g2::Config>(),
+            mul_projective::<ark_bn254::g2::Config>()
+        );
+    }
+
+    #[test]
+    pub fn mul_affine_g1() {
+        assert_eq!(
+            mul_affine::<bn254::g1::Config>(),
+            mul_affine::<ark_bn254::g1::Config>()
+        );
+    }
+
+    #[test]
+    pub fn mul_affine_g2() {
+        assert_eq!(
+            mul_affine::<bn254::g2::Config>(),
+            mul_affine::<ark_bn254::g2::Config>()
+        );
+    }
+}

--- a/native/src/accelerated_bn/mod.rs
+++ b/native/src/accelerated_bn/mod.rs
@@ -1,0 +1,23 @@
+// Copyright 2024, Horizen Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![warn(missing_docs)]
+
+pub mod bn254;
+
+mod utils;
+
+#[cfg(test)]
+mod test_utils;

--- a/native/src/accelerated_bn/test_utils.rs
+++ b/native/src/accelerated_bn/test_utils.rs
@@ -1,0 +1,56 @@
+// Copyright 2024, Horizen Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ark_ec::{
+    pairing::Pairing,
+    short_weierstrass::{Affine, SWCurveConfig},
+    AffineRepr, CurveGroup, Group,
+};
+
+pub fn multi_pairing<P: Pairing>() -> P::TargetField {
+    let g = P::G1::generator();
+    let h = P::G2::generator();
+    P::multi_pairing([g], [h]).0
+}
+
+pub fn msm<G: SWCurveConfig>() -> (G::BaseField, G::BaseField, bool) {
+    let scalars: Vec<G::ScalarField> = vec![1_u64, 2_u64, 3_u64, 4_u64, 5_u64]
+        .into_iter()
+        .map(Into::into)
+        .collect();
+
+    let points = vec![G::GENERATOR; 5];
+
+    G::msm(&points, &scalars)
+        .map(|result| result.into_affine())
+        .map(|Affine { x, y, infinity }| (x, y, infinity))
+        .unwrap()
+}
+
+pub fn mul_projective<G: SWCurveConfig>() -> (G::BaseField, G::BaseField, bool) {
+    let scalar: u64 = 123456789;
+    let point = G::GENERATOR.into_group();
+
+    let Affine { x, y, infinity } = G::mul_projective(&point, &[scalar]).into_affine();
+    (x, y, infinity)
+}
+
+pub fn mul_affine<G: SWCurveConfig>() -> (G::BaseField, G::BaseField, bool) {
+    let scalar: u64 = 123456789;
+    let point = G::GENERATOR;
+
+    let Affine { x, y, infinity } = G::mul_affine(&point, &[scalar]).into_affine();
+    (x, y, infinity)
+}

--- a/native/src/accelerated_bn/utils.rs
+++ b/native/src/accelerated_bn/utils.rs
@@ -1,0 +1,92 @@
+// Copyright 2024, Horizen Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Generic executions of the operations for *Arkworks* elliptic curves.
+
+// As not all functions are used by each elliptic curve and some elliptic
+// curve may be excluded by the build we resort to `#[allow(unused)]` to
+// suppress the expected warning.
+
+use ark_ec::{
+    pairing::{MillerLoopOutput, Pairing},
+    short_weierstrass::{Affine as SWAffine, Projective as SWProjective, SWCurveConfig},
+    CurveConfig, VariableBaseMSM,
+};
+use ark_scale::{
+    ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate},
+    scale::{Decode, Encode},
+};
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+// SCALE encoding parameters shared by all the enabled modules
+const SCALE_USAGE: u8 = ark_scale::make_usage(Compress::No, Validate::No);
+type ArkScale<T> = ark_scale::ArkScale<T, SCALE_USAGE>;
+type ArkScaleProjective<T> = ark_scale::hazmat::ArkScaleProjective<T>;
+
+#[inline(always)]
+pub fn encode<T: CanonicalSerialize>(val: T) -> Vec<u8> {
+    ArkScale::from(val).encode()
+}
+
+#[inline(always)]
+pub fn decode<T: CanonicalDeserialize>(mut buf: &[u8]) -> Result<T, ()> {
+    ArkScale::<T>::decode(&mut buf).map_err(|_| ()).map(|v| v.0)
+}
+
+#[inline(always)]
+pub fn encode_proj_sw<T: SWCurveConfig>(val: &SWProjective<T>) -> Vec<u8> {
+    ArkScaleProjective::from(val).encode()
+}
+
+#[inline(always)]
+pub fn decode_proj_sw<T: SWCurveConfig>(mut buf: &[u8]) -> Result<SWProjective<T>, ()> {
+    ArkScaleProjective::decode(&mut buf)
+        .map_err(|_| ())
+        .map(|v| v.0)
+}
+
+#[cfg(feature = "std")]
+pub mod native {
+    use super::*;
+
+    pub fn multi_miller_loop<T: Pairing>(g1: &[u8], g2: &[u8]) -> Result<Vec<u8>, ()> {
+        let g1 = decode::<Vec<<T as Pairing>::G1Affine>>(g1)?;
+        let g2 = decode::<Vec<<T as Pairing>::G2Affine>>(g2)?;
+        let res = T::multi_miller_loop(g1, g2);
+        Ok(encode(res.0))
+    }
+
+    pub fn final_exponentiation<T: Pairing>(target: &[u8]) -> Result<Vec<u8>, ()> {
+        let target = decode::<<T as Pairing>::TargetField>(target)?;
+        let res = T::final_exponentiation(MillerLoopOutput(target)).ok_or(())?;
+        Ok(encode(res.0))
+    }
+
+    pub fn msm_sw<T: SWCurveConfig>(bases: &[u8], scalars: &[u8]) -> Result<Vec<u8>, ()> {
+        let bases = decode::<Vec<SWAffine<T>>>(bases)?;
+        let scalars = decode::<Vec<<T as CurveConfig>::ScalarField>>(scalars)?;
+        let res = <SWProjective<T> as VariableBaseMSM>::msm(&bases, &scalars).map_err(|_| ())?;
+        Ok(encode_proj_sw(&res))
+    }
+
+    pub fn mul_projective_sw<T: SWCurveConfig>(base: &[u8], scalar: &[u8]) -> Result<Vec<u8>, ()> {
+        let base = decode_proj_sw::<T>(base)?;
+        let scalar = decode::<Vec<u64>>(scalar)?;
+        let res = <T as SWCurveConfig>::mul_projective(&base, &scalar);
+        Ok(encode_proj_sw(&res))
+    }
+}

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -18,6 +18,7 @@
 use codec::{Decode, Encode};
 use sp_runtime_interface::pass_by::PassByCodec;
 
+mod accelerated_bn;
 mod groth16;
 mod risc0;
 mod ultraplonk;
@@ -73,6 +74,10 @@ pub use groth16::groth_16_bn_254_verify;
 #[cfg(feature = "std")]
 pub use groth16::groth_16_bn_254_verify::HostFunctions as Groth16Bn254VerifierHostFunctions;
 
+pub use accelerated_bn::bn254;
+#[cfg(feature = "std")]
+pub use accelerated_bn::bn254::host_calls::HostFunctions as AcceleratedBn254HostFunctions;
+
 #[cfg(feature = "std")]
 pub type HLNativeHostFunctions = (
     ZksyncVerifierHostFunctions,
@@ -81,4 +86,5 @@ pub type HLNativeHostFunctions = (
     UltraplonkVerifierHostFunctions,
     Groth16Bn254VerifierHostFunctions,
     Groth16Bls12VerifierHostFunctions,
+    AcceleratedBn254HostFunctions,
 );


### PR DESCRIPTION
Added functionality for performing cryptographic operations using the BN254 pairing-friendly curve. This functionality is made available through host functions introduced inside the `native` crate through the `accelerated_bn` module.