### PR TITLE
zkv-lib: retry to submit extrinsics when marked as invalid

### DIFF
--- a/zombienet-tests/0013-xcm.zndsl
+++ b/zombienet-tests/0013-xcm.zndsl
@@ -15,4 +15,4 @@ alice: parachain 1599 block height is at least 3 within 100 seconds
 
 ### Javascript test invocation
 alice: js-script ./js_scripts/0013-xcm/relay_send.js with "1000000000000000000,0xa2bffddad9c4d7d36055119ce34867b523f4711be871785c286a91fab21fd175" return is equal to 1 within 20 seconds
-collator-alice: js-script ./js_scripts/0013-xcm/para_recv_sendback.js with "1000000000000000000,0xa2bffddad9c4d7d36055119ce34867b523f4711be871785c286a91fab21fd175" return is equal to 1 within 100 seconds
+collator-alice: js-script ./js_scripts/0013-xcm/para_recv_sendback.js with "1000000000000000000,0xa2bffddad9c4d7d36055119ce34867b523f4711be871785c286a91fab21fd175" return is equal to 1 within 200 seconds

--- a/zombienet-tests/js_scripts/0008-update-runtime-multisig-scheduler.js
+++ b/zombienet-tests/js_scripts/0008-update-runtime-multisig-scheduler.js
@@ -38,7 +38,7 @@ async function run(nodeName, networkInfo, args) {
      *****************************************************************************************************/
 
     const newSudoKey = api.tx.sudo.setKey(Ss58MultiAddress);
-    await submitExtrinsic(newSudoKey, alice, BlockUntil.Finalized, undefined);
+    await submitExtrinsic(api, newSudoKey, alice, BlockUntil.Finalized, undefined);
 
     const newSudoKeyOption = await api.query.sudo.key();
     if (newSudoKeyOption.isSome && newSudoKeyOption.unwrap().toString() !== Ss58MultiAddress) {
@@ -81,7 +81,7 @@ async function run(nodeName, networkInfo, args) {
         0
     );
 
-    await submitExtrinsic(proposal, alice, BlockUntil.InBlock, undefined);
+    await submitExtrinsic(api, proposal, alice, BlockUntil.InBlock, undefined);
 
     const info = await api.query.multisig.multisigs(
         multisigAddress,
@@ -96,7 +96,7 @@ async function run(nodeName, networkInfo, args) {
         paymentInfo.weight
     );
 
-    await submitExtrinsic(approval, bob, BlockUntil.InBlock, undefined);
+    await submitExtrinsic(api, approval, bob, BlockUntil.InBlock, undefined);
 
     const { block: currentBlockNumber } = await api.rpc.chain.getBlock();
     const blockNumberEnd = currentBlockNumber.header.number.toNumber();

--- a/zombienet-tests/js_scripts/0009-proof_on_disabled_verifier_should_pay_just_a_little_fee.js
+++ b/zombienet-tests/js_scripts/0009-proof_on_disabled_verifier_should_pay_just_a_little_fee.js
@@ -39,7 +39,7 @@ async function run(nodeName, networkInfo, _args) {
     const disableTx = api.tx.settlementFFlonkPallet.disable(true);
     const sudoDisableTx = api.tx.sudo.sudo(disableTx)
 
-    if (!receivedEvents(await submitExtrinsic(sudoDisableTx, alice, BlockUntil.InBlock))) {
+    if (!receivedEvents(await submitExtrinsic(api, sudoDisableTx, alice, BlockUntil.InBlock))) {
         return ReturnCode.ErrCannotDisable;
     };
 

--- a/zombienet-tests/js_scripts/0013-xcm/relay_send.js
+++ b/zombienet-tests/js_scripts/0013-xcm/relay_send.js
@@ -87,7 +87,7 @@ async function run(nodeName, networkInfo, args) {
     const weight_limit = 'Unlimited';
     const teleport = await api.tx.xcmPallet.teleportAssets(dest, beneficiary, assets, fee_asset_item);
 
-    if (!receivedEvents(await submitExtrinsic(teleport, alice, BlockUntil.InBlock, undefined))) {
+    if (!receivedEvents(await submitExtrinsic(api, teleport, alice, BlockUntil.InBlock, undefined))) {
         return ReturnCode.ExtrinsicUnsuccessful;
     }
 


### PR DESCRIPTION
This PR makes `zkv-lib` more robust when sending extrinsics. More specifically, when an extrinsic is marked as `Invalid`, it might be possible to send it again and have it accepted in a block. With this PR, `zkv-lib` automatically tries to do this.

This is of particular interest for parachains in our zombienet `paratest` configuration, where the probability of reorganizations is higher, and extrinsics sent in consecutive blocks might be marked as `Invalid`.