### PR TITLE
Key-types injection entrypoint addition

### DIFF
--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -209,6 +209,16 @@ if [ -f "${ZKV_SECRET_PHRASE_PATH}" ]; then
     --scheme Sr25519 \
     --suri "${ZKV_SECRET_PHRASE_PATH}" \
     --key-type imon
+  echo "Injecting key (para)"
+  ${ZKV_NODE} key insert "${injection_args[@]}" \
+    --scheme Sr25519 \
+    --suri "${ZKV_SECRET_PHRASE_PATH}" \
+    --key-type para
+  echo "Injecting key (audi)"
+  ${ZKV_NODE} key insert "${injection_args[@]}" \
+    --scheme Sr25519 \
+    --suri "${ZKV_SECRET_PHRASE_PATH}" \
+    --key-type audi
 fi
 
 # Node-key handling


### PR DESCRIPTION
Adding audi and para keys injection in the docker image entrypoint to enable relay-chain functionality "out of the box". 