### PR TITLE
Parameterize CI vars

### DIFF
--- a/.github/workflows/CI-build-test-publish.yml
+++ b/.github/workflows/CI-build-test-publish.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   DOCKER_HUB_ORG: horizenlabs
-  DOCKER_IMAGE_BUILD_NAME: zkverify
+  DOCKER_IMAGE_BUILD_NAME: ${{ vars.DOCKER_IMAGE_BUILD_NAME }}
 
 jobs:
   build:
@@ -40,17 +40,17 @@ jobs:
       - name: Build docker image
         run: |
           if [[ "${{ inputs.chain }}" == "solo" ]]; then
-            docker build --build-arg PROFILE=production -f "docker/dockerfiles/zkv-node.Dockerfile" -t "${DOCKER_HUB_ORG}/zkverify-solo" .
-            echo "DOCKER_IMAGE_NAME=${DOCKER_HUB_ORG}/zkverify-solo" >> $GITHUB_ENV
+            docker build --build-arg PROFILE=production -f "docker/dockerfiles/zkv-node.Dockerfile" -t "${DOCKER_HUB_ORG}/${DOCKER_IMAGE_BUILD_NAME}-solo" .
+            echo "DOCKER_IMAGE_NAME=${DOCKER_HUB_ORG}/${DOCKER_IMAGE_BUILD_NAME}-solo" >> $GITHUB_ENV
           elif [[ "${{ inputs.chain }}" == "relay" ]]; then
-            docker build --build-arg PROFILE=production -f "docker/dockerfiles/zkv-relay.Dockerfile" -t "${DOCKER_HUB_ORG}/zkverify-relay" .
-            echo "DOCKER_IMAGE_NAME=${DOCKER_HUB_ORG}/zkverify-relay" >> $GITHUB_ENV
+            docker build --build-arg PROFILE=production -f "docker/dockerfiles/zkv-relay.Dockerfile" -t "${DOCKER_HUB_ORG}/${DOCKER_IMAGE_BUILD_NAME}-relay" .
+            echo "DOCKER_IMAGE_NAME=${DOCKER_HUB_ORG}/${DOCKER_IMAGE_BUILD_NAME}-relay" >> $GITHUB_ENV
           fi
       
       - name: Save the Docker image as a tarball
         id: create-tar-file
         run: |       
-          ARTIFACT_NAME="zkverify-${{ inputs.chain }}"
+          ARTIFACT_NAME="${DOCKER_IMAGE_BUILD_NAME}-${{ inputs.chain }}"
           TAR_FILE="${{github.workspace}}/${ARTIFACT_NAME}.tar"
 
           echo "artifact_name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
@@ -99,7 +99,8 @@ jobs:
   #         echo "Loaded image ${IMAGE_NAME}"
   #         TEST_TAG=test
   #         echo "TEST_TAG=${TEST_TAG}" >> $GITHUB_ENV
-  #         docker image tag "${IMAGE_NAME}" "${DOCKER_HUB_ORG}/${DOCKER_IMAGE_BUILD_NAME}:$TEST_TAG"
+  #         docker image tag "${IMAGE_NAME}" "${DOCKER_HUB_ORG}/zkverify:$TEST_TAG"
+  #         # TODO ideally we'd pass DOCKER_IMAGE_BUILD_NAME as another variable in 'with:' of the next block to the QA action and paramerize the image name there as well, instead of hard coding it to "${DOCKER_HUB_ORG}/zkverify:$TEST_TAG"
   #       shell: bash
 
   #     - name: Run test

--- a/.github/workflows/CI-build-test-publish.yml
+++ b/.github/workflows/CI-build-test-publish.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   build:
     runs-on:
-      group: zkVerify
+      group: ${{ vars.RUNNER_GROUP }}
     name: Build Docker image
     outputs:
       artifact_name: ${{ steps.create-tar-file.outputs.artifact_name }}
@@ -70,7 +70,7 @@ jobs:
   
   # execute-e2e-tests:
   #   runs-on:
-  #     group: zkVerify
+  #     group: ${{ vars.RUNNER_GROUP }}
   #   needs: build
   #   name: Execute E2E Tests
   #   outputs:

--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   build:
     runs-on:
-      group: zkVerify
+      group: ${{ vars.RUNNER_GROUP }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/CI-coverage.yml
+++ b/.github/workflows/CI-coverage.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   coverage:
     runs-on:
-      group: zkVerify
+      group: ${{ vars.RUNNER_GROUP }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   test:
     runs-on:
-      group: zkVerify
+      group: ${{ vars.RUNNER_GROUP }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/CI-zombienet-test.yml
+++ b/.github/workflows/CI-zombienet-test.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   zombienet-test:
     runs-on:
-      group: zkVerify
+      group: ${{ vars.RUNNER_GROUP }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/ci/docker.sh
+++ b/ci/docker.sh
@@ -59,7 +59,7 @@ if [ -n "${docker_tag_full:-}" ]; then
     log_info "=== Using Docker image artifact from upstream ==="
     image_name="$(docker load -i "${GITHUB_WORKSPACE}/${image_artifact}.tar" | awk '/Loaded image:/ { print $3 }')"
     log_info "=== Loaded image ${image_name} ==="
-  else 
+  else
     fn_die "ERROR: No artifact specified with --image-artifact. Exiting ..."
   fi
 
@@ -79,7 +79,7 @@ if [ -n "${docker_tag_full:-}" ]; then
   fi
 
   # Append -relay to tag names for relay chain images
-  if [[ "${image_artifact}" == "zkverify-relay" ]]; then
+  if [[ "${image_artifact}" == "${docker_image_build_name}-relay" ]]; then
     docker_tag_full="${docker_tag_full}-relay"
     for publish_tag in "${!publish_tags[@]}"; do
       publish_tags["${publish_tag}"]="${publish_tags["${publish_tag}"]}-relay"


### PR DESCRIPTION
This PR makes it possible to configure different GH Action runner groups and docker image ${org}/${name} values for a copy of this repo for testing purposes, while keeping the code of the two repositories identical.