### PR TITLE
Add support for --password-filename to docker

### DIFF
--- a/docker/dockerfiles/zkv-node.Dockerfile
+++ b/docker/dockerfiles/zkv-node.Dockerfile
@@ -48,6 +48,7 @@ USER root
 WORKDIR /app
 
 COPY docker/scripts/entrypoint.sh .
+COPY docker/scripts/remove_password_file.sh .
 COPY --from=builder "/usr/src/node/target/${PROFILE}/zkv-node" "/usr/local/bin/"
 COPY --from=builder "/usr/src/node/target/${PROFILE}/wbuild/zkv-runtime/zkv_runtime.compact.compressed.wasm" "./zkv_runtime.compact.compressed.wasm"
 RUN chmod -R a+rx "/usr/local/bin"

--- a/docker/dockerfiles/zkv-relay.Dockerfile
+++ b/docker/dockerfiles/zkv-relay.Dockerfile
@@ -48,6 +48,7 @@ USER root
 WORKDIR /app
 
 COPY docker/scripts/entrypoint.sh .
+COPY docker/scripts/remove_password_file.sh .
 COPY --from=builder "/usr/src/node/target/${PROFILE}/zkv-relay" "/usr/local/bin/"
 COPY --from=builder "/usr/src/node/target/${PROFILE}/zkv-relay-execute-worker" "/usr/local/bin/"
 COPY --from=builder "/usr/src/node/target/${PROFILE}/zkv-relay-prepare-worker" "/usr/local/bin/"

--- a/docker/scripts/remove_password_file.sh
+++ b/docker/scripts/remove_password_file.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+echo "Waiting for node to launch"
+until pid=$(pidof $1)
+do
+    sleep 1
+done
+
+echo "Waiting for node to complete startup"
+cat /proc/${pid}/fd/2 | grep -qe "🏆 Imported"
+
+if [[ $? == 0 ]]; then
+    echo "Node started and synced; wiping password"
+    #Remove the file. Alternatively, we could 'echo "=== removed ===" > $2'
+    rm -f $2
+fi


### PR DESCRIPTION
This PR updates the docker configuration for validators to allow using a password (optionally) for accessing the keystore.

This password is provided through a file, which is remove automatically once the node completes the startup.

Ultimately, this allows not keeping part of the secrets in cleartext on the validator filesystem.