### PR TITLE
Swapped TestHooks for native::bn254::CurveHooks

### DIFF
--- a/native/src/accelerated_bn/bn254.rs
+++ b/native/src/accelerated_bn/bn254.rs
@@ -51,7 +51,7 @@ pub use self::{
 };
 
 /// Curve hooks jumping into [`host_calls`] host functions.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct HostHooks;
 
 /// Configuration for *BN254* curve.

--- a/verifiers/ultraplonk/src/lib.rs
+++ b/verifiers/ultraplonk/src/lib.rs
@@ -20,10 +20,12 @@ use hp_verifiers::{Cow, Verifier, VerifyError};
 use sp_core::{Get, H256};
 use sp_std::{marker::PhantomData, vec::Vec};
 
+use native::bn254::HostHooks as CurveHooksImpl;
+
+use ultraplonk_no_std::key::VerificationKey;
 pub use ultraplonk_no_std::PROOF_SIZE;
 pub use ultraplonk_no_std::PUBS_SIZE;
 pub use ultraplonk_no_std::VK_SIZE;
-use ultraplonk_no_std::{key::VerificationKey, testhooks::TestHooks as CurveHooksImpl};
 pub type Proof = Vec<u8>;
 pub type Pubs = Vec<[u8; PUBS_SIZE]>;
 pub type Vk = [u8; VK_SIZE];


### PR DESCRIPTION
This PR simply swaps the concrete `CurveHooks` implementation from ultraplonk-no-std's `TestHooks` to the one found inside zkVerify's `native` crate.