### PR TITLE
Implemented the runtime migration that remove all ultraplonk vk and refunds the owners.

### DIFF
--- a/pallets/verifiers/macros/src/lib.rs
+++ b/pallets/verifiers/macros/src/lib.rs
@@ -118,6 +118,7 @@ fn verifier_render(item: Item) -> proc_macro2::TokenStream {
         pub type Pallet<#t> = #crate_name::Pallet<#t, #ident #generic>;
         pub type Event<#t> = #crate_name::Event<#t, #ident #generic>;
         pub type Error<#t> = #crate_name::Error<#t, #ident #generic>;
+        pub type Tickets<#t> = #crate_name::Tickets<#t, #ident #generic>;
         pub use #crate_name::{
             __substrate_call_check, __substrate_event_check, tt_default_parts, tt_error_token,
         };
@@ -190,6 +191,7 @@ mod tests {
                 pub type Pallet<T> = pallet_verifiers::Pallet<T, Ver>;
                 pub type Event<T> = pallet_verifiers::Event<T, Ver>;
                 pub type Error<T> = pallet_verifiers::Error<T, Ver>;
+                pub type Tickets<T> = pallet_verifiers::Tickets<T, Ver>;
                 pub use pallet_verifiers::{
                     __substrate_call_check, __substrate_event_check, tt_default_parts, tt_error_token,
                 };
@@ -221,6 +223,7 @@ mod tests {
                 pub type Pallet<R> = pallet_verifiers::Pallet<R, Ver<R>>;
                 pub type Event<R> = pallet_verifiers::Event<R, Ver<R>>;
                 pub type Error<R> = pallet_verifiers::Error<R, Ver<R>>;
+                pub type Tickets<R> = pallet_verifiers::Tickets<R, Ver<R>>;
                 pub use pallet_verifiers::{
                     __substrate_call_check, __substrate_event_check, tt_default_parts, tt_error_token,
                 };

--- a/pallets/verifiers/src/migrations/mod.rs
+++ b/pallets/verifiers/src/migrations/mod.rs
@@ -1,4 +1,36 @@
 //! Storage migrations.
 
+use frame_support::traits::UncheckedOnRuntimeUpgrade;
+use hp_verifiers::Verifier;
+use sp_core::Get;
+
+use crate::Config;
+use frame_support::traits::Consideration;
+
 /// Migration from v0 to v1
 pub mod v1;
+
+/// Implements [`UncheckedOnRuntimeUpgrade`], for clean all vk storage and ticket and refound all held founds.
+pub struct RemoveAllVks<T, I>(core::marker::PhantomData<(T, I)>);
+
+impl<T: Config<I>, I: 'static> UncheckedOnRuntimeUpgrade for RemoveAllVks<T, I>
+where
+    I: Verifier,
+{
+    /// Migrate the storage from V0 to V1.
+    fn on_runtime_upgrade() -> frame_support::weights::Weight {
+        let n = crate::Vks::<T, I>::drain().count() as u64;
+        let m = crate::Tickets::<T, I>::drain()
+            .map(|((account_id, vk), t)| {
+                if let Some(ticket) = t {
+                    if let Err(e) = ticket.drop(&account_id) {
+                        log::error!(
+                            "Error dropping ticket on migration ({account_id:?},{vk}): {e:?}"
+                        );
+                    }
+                }
+            })
+            .count() as u64;
+        T::DbWeight::get().reads_writes(n + m, n + m)
+    }
+}

--- a/runtime/src/migrations.rs
+++ b/runtime/src/migrations.rs
@@ -18,6 +18,81 @@
 #[allow(unused_imports)]
 use super::*;
 
+mod migrate_change_vk_format {
+
+    use super::*;
+
+    pub struct RemoveUltraplonkVks;
+
+    #[cfg(feature = "try-runtime")]
+    type Balances = sp_std::collections::btree_map::BTreeMap<crate::AccountId, crate::Balance>;
+
+    impl RemoveUltraplonkVks {
+        #[cfg(feature = "try-runtime")]
+        fn get_all_tickets_balances() -> Balances {
+            use frame_support::traits::fungible::Inspect;
+
+            pallet_ultraplonk_verifier::Tickets::<Runtime>::iter()
+                .map(|((id, _), _)| {
+                    let balance = crate::Balances::balance(&id);
+                    (id, balance)
+                })
+                .collect::<sp_std::collections::btree_map::BTreeMap<_, _>>()
+        }
+    }
+
+    impl frame_support::traits::OnRuntimeUpgrade for RemoveUltraplonkVks {
+        #[cfg(feature = "try-runtime")]
+        fn pre_upgrade() -> Result<sp_std::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
+            use codec::Encode;
+
+            frame_support::ensure!(
+                crate::System::last_runtime_upgrade_spec_version() < 10_000,
+                "must upgrade linearly"
+            );
+
+            Ok(Self::get_all_tickets_balances().encode())
+        }
+
+        /// Migrates validators and nominators to bags list for the staking pallet.
+        fn on_runtime_upgrade() -> Weight {
+            use frame_support::traits::UncheckedOnRuntimeUpgrade;
+            if crate::System::last_runtime_upgrade_spec_version() >= 10_000 {
+                log::warn!("Remove old migration");
+                return Default::default();
+            }
+            let w = pallet_verifiers::migrations::RemoveAllVks::<
+                Runtime,
+                pallet_ultraplonk_verifier::Ultraplonk<Runtime>,
+            >::on_runtime_upgrade();
+
+            log::info!("Removed all vk from ultraplonk-verifier");
+
+            w
+        }
+
+        #[cfg(feature = "try-runtime")]
+        fn post_upgrade(state: sp_std::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+            use codec::Decode;
+
+            let old = Balances::decode(&mut &state[..]).unwrap();
+
+            let mut ok = true;
+
+            for (id, old_balance) in old.iter() {
+                use frame_support::traits::fungible::Inspect;
+                let new_balance = crate::Balances::balance(&id);
+                if old_balance >= &new_balance {
+                    log::warn!("User {id:?} balance has not refunded [old] {old_balance} [new] {new_balance}");
+                    ok = false;
+                }
+            }
+            frame_support::ensure!(ok, "Some users not refunded");
+            Ok(())
+        }
+    }
+}
+
 pub mod migrate_staking_to_bags_list {
     use super::*;
     use frame_election_provider_support::SortedListProvider;
@@ -79,4 +154,4 @@ pub mod migrate_staking_to_bags_list {
     }
 }
 
-pub type Unreleased = ();
+pub type Unreleased = migrate_change_vk_format::RemoveUltraplonkVks;


### PR DESCRIPTION
No unit test implemented, but a check on runtime upgrade that the use are refunded.

I test the upgrade and it works, also the refound works. 

I DIDN'T TRY the try_runtime impl.