### PR TITLE
Fix pallet-claim benchmarks

### DIFF
--- a/pallets/claim/src/benchmarking.rs
+++ b/pallets/claim/src/benchmarking.rs
@@ -24,10 +24,7 @@ use sp_runtime::Saturating;
 fn get_beneficiaries_map<T: Config>(
     n: u32,
 ) -> (BTreeMap<T::AccountId, BalanceOf<T>>, BalanceOf<T>) {
-    let minimum_balance = <<T as Config>::Currency as Inspect<
-        <T as frame_system::Config>::AccountId,
-    >>::minimum_balance();
-    let base_amount = BalanceOf::<T>::from(minimum_balance);
+    let base_amount = BalanceOf::<T>::from(T::Currency::minimum_balance());
     let mut total_amount = BalanceOf::<T>::zero();
     let beneficiaries_map = (1..=n)
         .into_iter()

--- a/pallets/claim/src/benchmarking.rs
+++ b/pallets/claim/src/benchmarking.rs
@@ -24,7 +24,10 @@ use sp_runtime::Saturating;
 fn get_beneficiaries_map<T: Config>(
     n: u32,
 ) -> (BTreeMap<T::AccountId, BalanceOf<T>>, BalanceOf<T>) {
-    let base_amount = BalanceOf::<T>::from(100_000u32);
+    let minimum_balance = <<T as Config>::Currency as Inspect<
+        <T as frame_system::Config>::AccountId,
+    >>::minimum_balance();
+    let base_amount = BalanceOf::<T>::from(minimum_balance);
     let mut total_amount = BalanceOf::<T>::zero();
     let beneficiaries_map = (1..=n)
         .into_iter()


### PR DESCRIPTION
Hardcoded balance made benchmarks fail when run against the actual runtime