### PR TITLE
Enforce locked Cargo.lock in CI

### DIFF
--- a/.github/workflows/CI-check-lockfile.yml
+++ b/.github/workflows/CI-check-lockfile.yml
@@ -1,0 +1,21 @@
+name: Check Cargo.lock
+
+run-name: "Workflow CI/CD Step: check Cargo.lock"
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  check-cargo-lock:
+    runs-on: warp-ubuntu-latest-x64-2x
+    name: Check lockfile
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check lockfile
+        uses: ./.github/actions/cmd-in-docker
+        with:
+          command: "cargo update --workspace --locked"
+          use_cache: "no"

--- a/.github/workflows/CI-orchestrator.yml
+++ b/.github/workflows/CI-orchestrator.yml
@@ -6,6 +6,10 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-lockfile-job:
+    name: Check lockfile job
+    uses: ./.github/workflows/CI-check-lockfile.yml
+
   build-job:
     name: Cargo build job
     uses: ./.github/workflows/CI-build.yml
@@ -44,7 +48,18 @@ jobs:
   set-overall-result:
     runs-on: warp-ubuntu-latest-x64-2x
     name: Set overall status
-    needs: [build-job, test-job, try-runtime-job, coverage-job, lint-format-job, zombienet-test-job, audit-job, feature-propagation-job]
+    needs:
+      [
+        check-lockfile-job,
+        build-job,
+        test-job,
+        try-runtime-job,
+        coverage-job,
+        lint-format-job,
+        zombienet-test-job,
+        audit-job,
+        feature-propagation-job,
+      ]
     if: ${{ github.event_name == 'pull_request' && !cancelled() }}
     outputs:
       branch-name: ${{ steps.get-info.outputs.BRANCH_NAME }}
@@ -81,7 +96,8 @@ jobs:
             OVERALL_STATUS="cancelled"
           else
             OVERALL_STATUS="success"
-            if [ "${{ needs.build-job.result }}" != "success" ] ||
+            if [ "${{ needs.check-lockfile-job.result }}" != "success" ] ||
+                [ "${{ needs.build-job.result }}" != "success" ] ||
                 [ "${{ needs.test-job.result }}" != "success" ] ||
                 [ "${{ needs.try-runtime-job.result }}" != "success" ] ||
                 [ "${{ needs.coverage-job.result }}" != "success" ] ||

--- a/.github/workflows/CI-orchestrator.yml
+++ b/.github/workflows/CI-orchestrator.yml
@@ -12,22 +12,27 @@ jobs:
 
   build-job:
     name: Cargo build job
+    needs: [check-lockfile-job]
     uses: ./.github/workflows/CI-build.yml
 
   test-job:
     name: Cargo test job
+    needs: [check-lockfile-job]
     uses: ./.github/workflows/CI-test.yml
 
   try-runtime-job:
     name: Try runtime job
+    needs: [check-lockfile-job]
     uses: ./.github/workflows/CI-try-runtime.yml
 
   coverage-job:
     name: Coverage job
+    needs: [check-lockfile-job]
     uses: ./.github/workflows/CI-coverage.yml
 
   lint-format-job:
     name: Lint and format job
+    needs: [check-lockfile-job]
     uses: ./.github/workflows/CI-lint-format.yml
 
   # Requires artifacts from the build job
@@ -38,10 +43,12 @@ jobs:
 
   audit-job:
     name: Cargo audit job
+    needs: [check-lockfile-job]
     uses: ./.github/workflows/CI-audit.yml
 
   feature-propagation-job:
     name: Feature propagation job
+    needs: [check-lockfile-job]
     uses: ./.github/workflows/CI-feature-propagation.yml
 
   # Only for pull requests and if not canceled


### PR DESCRIPTION
At the moment, CI doesn't catch possibly broken `Cargo.lock` lockfiles, because the default behavior of `cargo check`, `cargo build`, etc. is to silently fix problems inside the `Cargo.lock`. This issue can arise especially after rebases and merges.

The problem could be prevented by simply passing the `--locked` flag to the various `cargo check`s, and `cargo build`s used throughout the CI. However I decided to add a dedicated CI step that only targets this particular check, so that a developer can have a clearer feedback on why CI fails.