### PR TITLE
Refactor reference_machine_run_all.sh:

### DIFF
--- a/scripts/docker-compose-bench.yml
+++ b/scripts/docker-compose-bench.yml
@@ -15,14 +15,15 @@ services:
       - "${BENCH_BASE_PATH?err_unset}:${BENCH_BASE_PATH}:rw"
     blkio_config:
       device_read_iops:
-        - path: "${LOOP_DEV?err_unset}"
+        - path: "${DEVICE?err_unset}"
           rate: "${READ_IO?err_unset}"
       device_write_iops:
-        - path: "${LOOP_DEV?err_unset}"
+        - path: "${DEVICE?err_unset}"
           rate: "${WRITE_IO?err_unset}"
       device_read_bps:
-        - path: "${LOOP_DEV?err_unset}"
+        - path: "${DEVICE?err_unset}"
           rate: "${READ_BPS?err_unset}"
       device_write_bps:
-        - path: "${LOOP_DEV?err_unset}"
+        - path: "${DEVICE?err_unset}"
           rate: "${WRITE_BPS?err_unset}"
+    cpuset: 0,2,4,6,8,10,12,14

--- a/scripts/reference_machine_run_all.sh
+++ b/scripts/reference_machine_run_all.sh
@@ -7,7 +7,7 @@ ECHO_CMD="${ECHO_CMD:-false}"
 
 # functions
 
-check_root () {
+check_root() {
   local extra_msg="$1"
   if [ "$(whoami)" != 'root' ]; then
     echo "$(date --utc +%FT%T.%3NZ) Error: Run this script with 'sudo $0'.${extra_msg}"
@@ -15,15 +15,15 @@ check_root () {
   fi
 }
 
-prereqs () {
+prereqs() {
   # make sure we have all dependencies
   local INSTALL=""
   ! command -v cpupower &> /dev/null && INSTALL+="linux-tools-common "
   ! command -v jq &> /dev/null && INSTALL+="jq "
   ! command -v lscpu &> /dev/null && INSTALL+="util-linux "
-  ! command -v docker &> /dev/null && INSTALL+="docker-buildx-plugin docker-ce docker-ce-cli docker-ce-rootless-extras docker-compose-plugin"
+  ! command -v docker &> /dev/null && INSTALL+="docker-buildx-plugin docker-ce docker-ce-cli docker-ce-rootless-extras docker-compose-plugin "
   ! command -v sudo &> /dev/null && INSTALL+="sudo "
-  ! command -v mkfs.ext4 &> /dev/null && INSTALL+="e2fsprogs "
+  ! command -v mkfs.vfat &> /dev/null && INSTALL+="dosfstools "
   if [ -n "$INSTALL" ]; then
     check_root " We need to install dependencies: ${INSTALL}"
     apt-get update
@@ -41,7 +41,7 @@ prereqs () {
   IS_BENCHMACHINE="true"
 }
 
-set_cpu () {
+set_cpu() {
   # save values currently used
   FREQUENCY="$1" # kHz
   check_root " Elevated permissions required to set fixed CPU clock for reproducible benchmark results."
@@ -62,7 +62,7 @@ set_cpu () {
   HAVE_SET_CPU="true"
 }
 
-restore_cpu () {
+restore_cpu() {
   # restore CPU frequency settings
   [ "$HAVE_SET_CPU" = "false" ] && return 0
   check_root " Elevated permissons required to reset CPU clock to default settings."
@@ -73,29 +73,70 @@ restore_cpu () {
   cpupower frequency-set -u "$MAX_FREQ" > /dev/null 2>&1
 }
 
-setup_disk () {
-  local file="$1"
-  local mountpoint="$2"
-  local USER_ID="$3"
-  local GROUP_ID="$4"
-  # create a simulated ext4 formatted block device in memory
-  dd if=/dev/zero of="${file?err_unset}" bs=1024 count="$((1024**2*10))" && IMG_CREATED="true"
-  LOOP_DEV="$(losetup -f)"
-  losetup --sector-size=4096 --direct-io=on "${LOOP_DEV}" "${file}" && LOOP_CREATED="true"
-  mkfs.ext4 -O ^has_journal -E nodiscard "${LOOP_DEV}"
-  mount -odefaults,noatime "${LOOP_DEV}" "${mountpoint?err_unset}" && DEVICE_MOUNTED="true"
-  chown -R "${USER_ID}:${GROUP_ID}" "${mountpoint}"
+setup_disk() {
+  # create a simulated vfat formatted brd block device in memory
+  local mountpoint="$1"
+  local USER_ID="$2"
+  local GROUP_ID="$3"
+  DEVICE="/dev/ram0"
+  # rd_size in KiB, allocate 1GiB
+  modprobe brd rd_nr=1 rd_size="$((1024**2*1))" max_part=1 && BRD_CREATED="true"
+  # fill with 1GiB of random data
+  dd if=/dev/urandom of="${DEVICE}" bs=1024 count="$((1024**2*1))"
+  # use FAT32 because it supports -o sync, logical sector size == brd physical sector size == page size == 4096
+  mkfs.vfat -F32 -S4096 "${DEVICE}"
+  # mount with -o sync to force O_DIRECT disk access bypassing the page cache, which makes cgroup.blkio namesspace limits work in docker
+  mount -odefaults,noatime,sync,umask=000 "${DEVICE}" "${mountpoint?err_unset}" && DEVICE_MOUNTED="true"
 }
 
-cleanup_disk () {
-  local file="$1"
-  local mountpoint="$2"
-  [ "${DEVICE_MOUNTED}" = "true" ] && umount "${mountpoint?err_unset}"
-  [ "${LOOP_CREATED}" = "true" ] && losetup -d "${LOOP_DEV}"
-  [ "${IMG_CREATED}" = "true" ] && rm -f "${file?err_unset}"
-  [ "${MOUNT_IS_TMP}" ] && rm -rf "${mountpoint?err_unset}"
+disable_swap() {
+  echo 3 > /proc/sys/vm/drop_caches
+  swapoff -a && SWAP_DISABLED="true"
 }
 
+enable_swap() {
+  [ "${SWAP_DISABLED}" = "true" ] && swapon -a
+}
+
+cleanup_disk() {
+  local mountpoint="$1"
+  sync
+  if [ "${DEVICE_MOUNTED}" = "true" ]; then
+    while read -r pid; do
+      wait "${pid}"
+    done < <(lsof -F p "${mountpoint?err_unset}" | tr -d 'p')
+    sync
+    umount "${mountpoint?err_unset}"
+  fi
+  sync
+  [ "${MOUNT_IS_TMP}" = "true" ] && rm -rf "${mountpoint?err_unset}"
+  sync
+  if [ "${BRD_CREATED}" = "true" ]; then
+    i=0
+    while ! modprobe -r brd 2>/dev/null && [ "${i}" -lt 60 ]; do
+      sync
+      sleep 0.1
+      i="$((i+1))"
+    done
+  fi
+}
+
+kill_orphaned_containers() {
+  if [ "${BENCHMARK_STARTED}" = "true" ]; then
+    docker ps --format '{{.Names}}' | grep "scripts-zkverify-bench-run" | xargs -I{} docker kill {} 2>/dev/null
+  fi
+}
+
+# locking
+LOCKFILE="/var/lock/.$(basename "${BASH_SOURCE[0]}").lock"
+LOCKFD=99
+# shellcheck disable=SC2086
+_lock()        { flock -$1 $LOCKFD; }
+remove_lock()  { _lock u; _lock xn && rm -f "${LOCKFILE}"; }
+prepare_lock() { eval "exec $LOCKFD>\"${LOCKFILE}\""; }
+exlock_now()   { _lock xn; }  # obtain an exclusive lock immediately or fail
+
+prepare_lock
 check_root ""
 prereqs
 
@@ -108,15 +149,16 @@ IO_PROFILE="${IO_PROFILE:-aws.ebs.io2_8000}"
 # frequency in kHz
 cpu_profiles["aws.c7a.2xlarge"]="3500000"
 cpu_profiles["unconfined"]="5389000"
-io_profiles["aws.ebs.io2_8000"]='{"read_io":450,"write_io":450,"read_bps":1457520640,"write_bps":1457520640}'
+io_profiles["aws.ebs.io2_8000"]='{"read_io":97000,"write_io":97000,"read_bps":575438848,"write_bps":575438848}'
 io_profiles["unconfined"]='{"read_io":1000000000,"write_io":1000000000,"read_bps":53687091200,"write_bps":53687091200}'
 
 # config
 HAVE_SET_CPU="false"
-IMG_CREATED="false"
-LOOP_CREATED="false"
 DEVICE_MOUNTED="false"
 MOUNT_IS_TMP="false"
+SWAP_DISABLED="false"
+BRD_CREATED="false"
+BENCHMARK_STARTED="false"
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." &> /dev/null && pwd)"
 USER="$(stat -c '%U' "${ROOT_DIR}")"
 USER_ID="$(stat -c '%u' "${ROOT_DIR}")"
@@ -127,27 +169,40 @@ READ_BPS="$(jq -rc '.read_bps' <<< "${io_profiles[${IO_PROFILE}]}")"
 WRITE_BPS="$(jq -rc '.write_bps' <<< "${io_profiles[${IO_PROFILE}]}")"
 BENCH_BASE_PATH="$(mktemp -d)"
 grep -q "^/tmp/tmp\..*$" <<< "${BENCH_BASE_PATH}" && MOUNT_IS_TMP="true"
-EXT4_IMG="/dev/shm/ext4.img"
 USE_DOCKER="true"
 ENABLE_PALLETS="${ENABLE_PALLETS:-true}"
 ENABLE_OVERHEAD="${ENABLE_OVERHEAD:-true}"
 ENABLE_MACHINE="${ENABLE_MACHINE:-true}"
 # The space separated pallet list to benchmark (empty means all). Use the inent
-# version like `pallet_aggregate` and not the one with `-` 
+# version like `pallet_aggregate` and not the one with `-`
 PALLETS="${PALLETS:-}"
 
-export IS_BENCHMACHINE READ_IO WRITE_IO READ_BPS WRITE_BPS BENCH_BASE_PATH LOOP_DEV USE_DOCKER ENABLE_PALLETS ECHO_CMD ROOT_DIR
+export IS_BENCHMACHINE READ_IO WRITE_IO READ_BPS WRITE_BPS BENCH_BASE_PATH DEVICE USE_DOCKER ENABLE_PALLETS ECHO_CMD ROOT_DIR PALLETS
 
 # add exit handler to restore machine to base settings on exit or error
-exit_handler () {
+exit_handler() {
   restore_cpu
-  cleanup_disk "${EXT4_IMG}" "${BENCH_BASE_PATH}"
+  kill_orphaned_containers || true
+  cleanup_disk "${BENCH_BASE_PATH}" || true
+  enable_swap
+  remove_lock
 }
 
 trap exit_handler EXIT
 
+exlock_now || { echo -e "Error: this script cannot be run concurrently. Check no other users are running it and that the previous run completed without issues.\n\nWhen in doubt reboot the machine with 'sudo reboot'."; exit 1; }
+
+# run run_all_benchmarks.sh once without any enabled benchmarks
+# this will trigger a docker build if needed
+# doing this before underclocking the CPU will be faster
+IS_BENCHMACHINE="false" ENABLE_PALLETS="false" ENABLE_OVERHEAD="false" ENABLE_MACHINE="false" \
+  sudo --preserve-env=IS_BENCHMACHINE,READ_IO,WRITE_IO,READ_BPS,WRITE_BPS,BENCH_BASE_PATH,DEVICE,USE_DOCKER,ENABLE_PALLETS,ENABLE_OVERHEAD,ENABLE_MACHINE,PALLETS,ECHO_CMD,ROOT_DIR,PALLETS \
+  -u "${USER}" bash -c 'cd "${ROOT_DIR}"; "${ROOT_DIR}/scripts/run_all_benchmarks.sh"'
+
 # run benchmark
-setup_disk "${EXT4_IMG}" "${BENCH_BASE_PATH}" "${USER_ID}" "${GROUP_ID}"
+disable_swap
+setup_disk "${BENCH_BASE_PATH}" "${USER_ID}" "${GROUP_ID}"
 set_cpu "${cpu_profiles[${CPU_PROFILE}]}"
-sudo --preserve-env=IS_BENCHMACHINE,READ_IO,WRITE_IO,READ_BPS,WRITE_BPS,BENCH_BASE_PATH,LOOP_DEV,USE_DOCKER,ENABLE_PALLETS,ENABLE_OVERHEAD,ENABLE_MACHINE,PALLETS,ECHO_CMD,ROOT_DIR \
+BENCHMARK_STARTED="true"
+sudo --preserve-env=IS_BENCHMACHINE,READ_IO,WRITE_IO,READ_BPS,WRITE_BPS,BENCH_BASE_PATH,DEVICE,USE_DOCKER,ENABLE_PALLETS,ENABLE_OVERHEAD,ENABLE_MACHINE,PALLETS,ECHO_CMD,ROOT_DIR,PALLETS \
   -u "${USER}" bash -c 'cd "${ROOT_DIR}"; "${ROOT_DIR}/scripts/run_all_benchmarks.sh"'


### PR DESCRIPTION
* Use Linux brd (block ram disk) driver instead of loop device for benchmark disk

* Format disk with FAT32 which supports mounting with '-o sync' forcing O_DIRECT disk access

  * This makes cgroup.blkio namesspace limits work in docker consistently

* Disable swap prior to running the benchmark, reenable after

* Limit the number of CPUs to 8 vCPUs

  * Mirrors the CPU topology of an AWS c7a.2xlarge instance

  * Weights of pallets benefiting from multithreading will slightly increase

* Run 'run_all_benchmarks.sh' once without any enabled benchmarks before the actual test

  * This will trigger a docker build (if needed) before underclocking the CPU which will be faster

* Improve error handling and restoring of the machine to the base settings on exit, error or interruption

* Disallow concurrent script execution through exclusive locking