### PR TITLE
Filter out submit_proof extrinsics from Nontransfer proxy and related unit test.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21350,6 +21350,7 @@ dependencies = [
  "polkadot-primitives 16.0.0",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
+ "rstest",
  "scale-info",
  "serde_json",
  "sp-api",

--- a/pallets/verifiers/src/lib.rs
+++ b/pallets/verifiers/src/lib.rs
@@ -124,6 +124,15 @@ pub mod pallet {
         Vk(Box<K>),
     }
 
+    impl<K> sp_std::default::Default for VkOrHash<K>
+    where
+        K: sp_std::fmt::Debug + Clone + PartialEq + Encode + Decode + TypeInfo + MaxEncodedLen,
+    {
+        fn default() -> Self {
+            VkOrHash::Hash(H256::default())
+        }
+    }
+
     impl<K> VkOrHash<K>
     where
         K: sp_std::fmt::Debug + Clone + PartialEq + Encode + Decode + TypeInfo + MaxEncodedLen,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -120,6 +120,9 @@ xcm = { workspace = true }
 xcm-procedural = { workspace = true }
 hex-literal = { workspace = true }
 
+[dev-dependencies]
+rstest = { workspace = true }
+
 [build-dependencies]
 substrate-wasm-builder = { workspace = true, optional = true }
 

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -21,5 +21,6 @@ mod availability;
 mod misc;
 mod pallets_interact;
 mod payout;
+mod proxy;
 mod testsfixtures;
 mod use_correct_weights;

--- a/runtime/src/tests/proxy.rs
+++ b/runtime/src/tests/proxy.rs
@@ -1,0 +1,69 @@
+// Copyright 2024, Horizen Labs, Inc.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Here we write the integration tests for proxy logic.
+
+use frame_support::traits::InstanceFilter as _;
+use rstest::rstest;
+
+use crate::proxy::ProxyType;
+use crate::RuntimeCall;
+
+#[rstest]
+#[case::groth16_submit_proof(
+    RuntimeCall::SettlementGroth16Pallet(pallet_verifiers::Call::submit_proof {
+        vk_or_hash: Default::default(),
+        proof: Default::default(),
+        pubs: Default::default(),
+        domain_id: None,
+    })
+)]
+#[case::risc0_submit_proof(
+    RuntimeCall::SettlementRisc0Pallet(pallet_verifiers::Call::submit_proof {
+        vk_or_hash: Default::default(),
+        proof: pallet_risc0_verifier::Proof::V1_2(Default::default()).into(),
+        pubs: Default::default(),
+        domain_id: None,
+    })
+)]
+#[case::ultraplonk_submit_proof(
+    RuntimeCall::SettlementUltraplonkPallet(pallet_verifiers::Call::submit_proof {
+        vk_or_hash: Default::default(),
+        proof: Default::default(),
+        pubs: Default::default(),
+        domain_id: None,
+    })
+)]
+#[case::proofofsql_submit_proof(
+    RuntimeCall::SettlementProofOfSqlPallet(pallet_verifiers::Call::submit_proof {
+        vk_or_hash: Default::default(),
+        proof: Default::default(),
+        pubs: Default::default(),
+        domain_id: None,
+    })
+)]
+#[case::plonky2_submit_proof(
+    RuntimeCall::SettlementPlonky2Pallet(pallet_verifiers::Call::submit_proof {
+        vk_or_hash: Default::default(),
+        proof: Default::default(),
+        pubs: Default::default(),
+        domain_id: None,
+    })
+)]
+fn nontransfer_deny_extrinsic(#[case] call: RuntimeCall) {
+    let proxy = ProxyType::NonTransfer;
+
+    assert!(!proxy.filter(&call))
+}


### PR DESCRIPTION
Filter out submit_proof extrinsics from Nontransfer proxy and related unit test
Also add plonky2 to nontransfer proxy conf.

Just to give a little context about why verifier's `submit_proof` extrinsics cannot be classified as a `NonTransfer`. The short answer is that `submit_proof` hold funds and, when somebody call `aggregate` **transfer**  this funds from the held ones to the delivery owner (also to the aggregator caller but for this issue that's not the main concern). Starting from this consideration it's simple to imagine some kind of privilege escalation where an account A define a `NonTransfer` proxy account B, now B can first create a fake domain, set a delivery price and then send a proof to this domain in behave of A to just stole the founds from A.

