### PR TITLE
chore: fixed broken link

### DIFF
--- a/relay-node/test/runtime/constants/src/lib.rs
+++ b/relay-node/test/runtime/constants/src/lib.rs
@@ -45,7 +45,7 @@ pub mod time {
     // 1 in 4 blocks (on average, not counting collisions) will be primary babe blocks.
     // The choice of is done in accordance to the slot duration and expected target
     // block time, for safely resisting network delays of maximum two seconds.
-    // <https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#6-practical-results>
+    // <https://research.web3.foundation/Polkadot/protocols/block-production/Babe#6-practical-results>
     pub const PRIMARY_PROBABILITY: (u64, u64) = (1, 4);
 }
 


### PR DESCRIPTION
Hi! I fixed a broken link in `relay-node/test/runtime/constants/src/lib.rs`. 
The Web3 Foundation's research site structure has changed, and the old path under `/en/latest/...` no longer works.  Replaced it with the updated `/Polkadot/protocols/block-production/Babe#6-practical-results`.