### PR TITLE
fix risc0-derive test that fails on CI

### DIFF
--- a/verifiers/risc0/risc0-derive/src/lib.rs
+++ b/verifiers/risc0/risc0-derive/src/lib.rs
@@ -253,6 +253,6 @@ mod test {
             }
         };
 
-        assert_eq!(format!("{:#?}", expected), format!("{:#?}", out));
+        assert_eq!(expected.to_string(), out.to_string());
     }
 }


### PR DESCRIPTION
Some crate imports proc-macro2 with "span-location" feature that changes the debug output by adding the span info. But compare the display out is enough.