### PR TITLE
Update XCM config

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1822,9 +1822,8 @@ impl_runtime_apis! {
 
             pub mod xcm {
                 use super::*;
-                use xcm::v4::{Asset, AssetId, Assets, Location, InteriorLocation, Junction, Junctions::Here, NetworkId, Response};
+                use xcm::v4::{Asset, AssetId, Assets, Location, InteriorLocation, Junction, Junctions::Here, NetworkId, Response, Fungibility::Fungible};
                 use frame_benchmarking::BenchmarkError;
-                use xcm::latest::Fungibility::Fungible;
 
                 pub use pallet_xcm::benchmarking::Pallet as XcmPalletBench;
                 pub use pallet_xcm_benchmarks::fungible::Pallet as XcmPalletBenchFungible;

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -50,7 +50,7 @@ use crate::weights::pallet_xcm::ZKVWeight as XcmPalletZKVWeight;
 use crate::weights::xcm::ZKVWeight as XcmZKVWeight;
 
 const ZKV_GENESIS_HASH: [u8; 32] =
-    hex_literal::hex!("e2a4f521dbcba897cd2359adc5e7725f409b17f9ae129737904e5e8939c22a05");
+    hex_literal::hex!("ff7fe5a610f15fe7a0c52f94f86313fb7db7d3786e7f8acf2b66c11d5be7c242");
 
 parameter_types! {
     pub const RootLocation: Location = Here.into_location();
@@ -138,16 +138,25 @@ pub type XcmRouter = WithUniqueTopic<(
     ChildParachainRouter<Runtime, XcmPallet, PriceForChildParachainDelivery>,
 )>;
 
+// zkVerify-EVM-Parachain
+pub const ZKV_EVM_PARA_ID: u32 = 1;
+// paratest, included in this repository
 pub const TEST_PARA_ID: u32 = 1599;
+
 parameter_types! {
-    pub const Acme: AssetFilter = Wild(AllOf { fun: WildFungible, id: AssetId(TokenLocation::get()) });
+    pub const TVFYAsset: AssetFilter = Wild(AllOf { fun: WildFungible, id: AssetId(TokenLocation::get()) });
     pub TestParaLocation: Location = Parachain(TEST_PARA_ID).into_location();
-    pub AcmeForTest: (AssetFilter, Location) = (Acme::get(), TestParaLocation::get());
+    pub ZKVEvmParaLocation: Location = Parachain(ZKV_EVM_PARA_ID).into_location();
+    pub TVFYAssetForTest: (AssetFilter, Location) = (TVFYAsset::get(), TestParaLocation::get());
+    pub TVFYAssetForZKVEvm: (AssetFilter, Location) = (TVFYAsset::get(), ZKVEvmParaLocation::get());
     pub const MaxAssetsIntoHolding: u32 = 64;
 }
 
 /// ZKV Relay recognizes/respects Test parachain as teleporter for VFY.
-pub type TrustedTeleporters = xcm_builder::Case<AcmeForTest>;
+pub type TrustedTeleporters = (
+    xcm_builder::Case<TVFYAssetForTest>,
+    xcm_builder::Case<TVFYAssetForZKVEvm>,
+);
 
 pub struct OnlyParachains;
 impl Contains<Location> for OnlyParachains {

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -113,8 +113,6 @@ type LocalOriginConverter = (
 );
 
 parameter_types! {
-    /// The amount of weight an XCM operation takes. This is a safe overestimate.
-    pub const BaseXcmWeight: Weight = Weight::from_parts(1_000_000_000, 1024);
     /// Maximum number of instructions in a single XCM fragment. A sanity check against weight
     /// calculations getting too crazy.
     pub const MaxInstructions: u32 = 100;
@@ -140,18 +138,18 @@ pub const ZKV_EVM_PARA_ID: u32 = 1;
 pub const TEST_PARA_ID: u32 = 1599;
 
 parameter_types! {
-    pub const TVFYAsset: AssetFilter = Wild(AllOf { fun: WildFungible, id: AssetId(TokenLocation::get()) });
+    pub const VFY: AssetFilter = Wild(AllOf { fun: WildFungible, id: AssetId(TokenLocation::get()) });
     pub TestParaLocation: Location = Parachain(TEST_PARA_ID).into_location();
     pub ZKVEvmParaLocation: Location = Parachain(ZKV_EVM_PARA_ID).into_location();
-    pub TVFYAssetForTest: (AssetFilter, Location) = (TVFYAsset::get(), TestParaLocation::get());
-    pub TVFYAssetForZKVEvm: (AssetFilter, Location) = (TVFYAsset::get(), ZKVEvmParaLocation::get());
+    pub VFYForTest: (AssetFilter, Location) = (VFY::get(), TestParaLocation::get());
+    pub VFYForZKVEvm: (AssetFilter, Location) = (VFY::get(), ZKVEvmParaLocation::get());
     pub const MaxAssetsIntoHolding: u32 = 1;
 }
 
 /// ZKV Relay recognizes/respects Test parachain as teleporter for VFY.
 pub type TrustedTeleporters = (
-    xcm_builder::Case<TVFYAssetForTest>,
-    xcm_builder::Case<TVFYAssetForZKVEvm>,
+    xcm_builder::Case<VFYForTest>,
+    xcm_builder::Case<VFYForZKVEvm>,
 );
 
 pub struct OnlyParachains;
@@ -234,19 +232,6 @@ impl xcm_executor::Config for XcmConfig {
     type HrmpNewChannelOpenRequestHandler = ();
     type HrmpChannelAcceptedHandler = ();
     type HrmpChannelClosingHandler = ();
-}
-
-const FELLOWSHIP_ADMIN_INDEX: u32 = 1; // to be moved to some constants mod
-
-parameter_types! {
-    // `GeneralAdmin` pluralistic body.
-    pub const GeneralAdminBodyId: BodyId = BodyId::Administration;
-    // StakingAdmin pluralistic body.
-    pub const StakingAdminBodyId: BodyId = BodyId::Defense;
-    // FellowshipAdmin pluralistic body.
-    pub const FellowshipAdminBodyId: BodyId = BodyId::Index(FELLOWSHIP_ADMIN_INDEX);
-    // `Treasurer` pluralistic body.
-    pub const TreasurerBodyId: BodyId = BodyId::Treasury;
 }
 
 /// Type to convert an `Origin` type value into a `Location` value which represents an interior


### PR DESCRIPTION
This updates the XCM config so that:
- teleports are enabled for the zkVerify-EVM-Parachain (paraId `1`)
- xcm execution fees are computed and handled like all the other fees
- the networkId is updated to represent the Volta network