### PR TITLE
CI: Create Release and more

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -11,10 +11,26 @@ inputs:
     description: "Docker image name"
     required: true
     type: string
+  docker_image_suffix:
+    description: "Docker image name suffix"
+    type: string
+    default: '-relay'
   docker_hub_org:
     description: "Docker hub organization"
     type: string
     default: 'horizenlabs'
+  profile:
+    description: "Build profile"
+    type: string
+    default: 'production'
+  features:
+    description: "Build features"
+    type: string
+    default: 'metadata-hash'
+  dry_run:
+    description: "Dry run execution"
+    type: boolean
+    default: false
 
 outputs:
   artifact_name:
@@ -34,24 +50,27 @@ runs:
       shell: bash
       run: |
         echo "Building relay chain Docker image"
-        docker build --build-arg PROFILE=production \
-          --build-arg FEATURES=metadata-hash \
+        ${{inputs.dry_run}} && echo "*********************** Dry run mode enabled, skipping Docker build. ***********************"
+        ${{inputs.dry_run}} || docker build --build-arg "PROFILE=${{ inputs.profile }}" \
+          --build-arg "FEATURES=${{ inputs.features }}" \
           -f "docker/dockerfiles/zkv-relay.Dockerfile" \
-          -t ${{ inputs.docker_hub_org }}/${{ inputs.docker_image_name }}-relay .
+          -t ${{ inputs.docker_hub_org }}/${{ inputs.docker_image_name }}${{ inputs.docker_image_suffix }} .
 
-        echo "DOCKER_IMAGE_NAME=${{ inputs.docker_hub_org }}/${{ inputs.docker_image_name }}-relay" >> "${GITHUB_ENV}"
+        echo "DOCKER_IMAGE_NAME=${{ inputs.docker_hub_org }}/${{ inputs.docker_image_name }}${{ inputs.docker_image_suffix }}" >> "${GITHUB_ENV}"
 
     - name: Save the Docker image as a tarball
       id: create-tar-file
       shell: bash
       run: |
-        ARTIFACT_NAME="${{ inputs.docker_image_name }}-relay"
+        ARTIFACT_NAME="${{ inputs.docker_image_name }}${{ inputs.docker_image_suffix }}"
         TAR_FILE="${{github.workspace}}/${ARTIFACT_NAME}.tar"
 
         echo "artifact_name=$ARTIFACT_NAME" >> "${GITHUB_OUTPUT}"
         echo "TAR_FILE=$TAR_FILE" >> "${GITHUB_ENV}"
 
-        docker save "${DOCKER_IMAGE_NAME}" -o "${TAR_FILE}"
+        ${{inputs.dry_run}} && echo "*********************** Dry run mode enabled, skipping Docker build. ***********************"
+        ${{inputs.dry_run}} && echo "DRY-RUN -> ${DOCKER_IMAGE_NAME}" > "${TAR_FILE}"
+        ${{inputs.dry_run}} || docker save "${DOCKER_IMAGE_NAME}" -o "${TAR_FILE}"
 
     - name: Upload Docker image artifact
       uses: actions/upload-artifact@v4

--- a/.github/actions/cmd-in-docker/action.yml
+++ b/.github/actions/cmd-in-docker/action.yml
@@ -4,7 +4,7 @@ description: A composite action to run command(s) inside Docker with caching set
 
 inputs:
   command:
-    description: 'A command to run inside "image_name:image_tag" docker container (e.g., "cargo build -p mainchain --release")'
+    description: 'A command to run inside "image_name:image_tag" docker container (e.g., "cargo build -p zkv-relay --release")'
     required: true
     type: string
   use_cache:
@@ -12,7 +12,7 @@ inputs:
     required: true
     type: string
   cache_key:
-    description: 'The cache key name (e.g., "build-mainchain-cache")'
+    description: 'The cache key name (e.g., "build-relay-paratest")'
     required: false
     type: string
   image_name:
@@ -42,6 +42,11 @@ inputs:
     default: ''
   nodejs_version_install:
     description: 'Nodejs major version to install. If not provided nodejs is not being installed'
+    required: false
+    type: string
+    default: ''
+  skip_wasm_build:
+    description: 'If enable disable the runtime wasm build (reduces build time)'
     required: false
     type: string
     default: ''
@@ -83,6 +88,7 @@ runs:
         CMAKE_INSTALL: ${{ inputs.cmake_install }}
         CARGO_BINARIES_INSTALL: ${{ inputs.cargo_binaries_install }}
         NODEJS_VERSION_INSTALL: ${{ inputs.nodejs_version_install }}
+        SKIP_WASM_BUILD: ${{ inputs.skip_wasm_build }}
         DOCKER_BUILD_DIR: /build
         DOCKER_CARGO_HOME: /tmp/.cargo
       run: |

--- a/.github/workflows/CI-build-docker-image-manually.yml
+++ b/.github/workflows/CI-build-docker-image-manually.yml
@@ -1,0 +1,49 @@
+name: Build Docker Image Custom
+
+on:
+  workflow_dispatch:
+    inputs:
+      docker_image_name:
+        description: "Docker image name"
+        required: true
+        type: string
+      docker_image_suffix:
+        description: "Docker image name suffix"
+        type: string
+        default: '-relay'
+      docker_hub_org:
+        description: "Docker hub organization"
+        type: string
+        default: 'horizenlabs'
+      profile:
+        description: "Build profile"
+        type: string
+        default: 'production'
+      features:
+        description: "Build features"
+        type: string
+        default: 'metadata-hash'
+      dry_run:
+        description: "Dry run execution"
+        type: boolean
+        default: false
+
+jobs:
+  build-docker:
+    runs-on: warp-ubuntu-latest-x64-8x
+    name: Build Docker image Manually
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Docker build
+        id: build-docker-image
+        uses: ./.github/actions/build-docker-image
+        with:
+          ref: ${{ git.ref }}
+          docker_image_name: ${{ inputs.docker_image_name }}
+          docker_image_suffix: ${{ inputs.docker_image_suffix }}
+          docker_hub_org: ${{ inputs.docker_hub_org }}
+          profile: ${{ inputs.profile }}
+          features: ${{ inputs.features }}
+          dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/CI-coverage.yml
+++ b/.github/workflows/CI-coverage.yml
@@ -19,12 +19,13 @@ jobs:
         with:
           command: >-
             /bin/bash -c 'set -o pipefail && cargo llvm-cov clean --workspace && find . -name \"*.profraw\" -delete
-            && cargo llvm-cov --all-features --workspace --exclude mainchain --exclude zkv-relay --exclude paratest-node --exclude test-service --lcov --output-path lcov.info
+            && cargo llvm-cov --all-features --workspace --exclude zkv-relay --exclude paratest-node --exclude test-service --lcov --output-path lcov.info
             && cargo llvm-cov report --json --output-path coverage_report.json --summary-only && cargo llvm-cov report | tee coverage_summary.txt'
           use_cache: 'yes'
           cache_key: 'coverage'
           lld_install: 'yes'
           cargo_binaries_install: cargo-llvm-cov
+          skip_wasm_build: 'yes'
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-lint-format.yml
+++ b/.github/workflows/CI-lint-format.yml
@@ -21,6 +21,7 @@ jobs:
           use_cache: "yes"
           cache_key: "lint-format"
           lld_install: "yes"
+          skip_wasm_build: "yes"
 
       - name: Upload lint artifacts
         if: ${{ !cancelled() }}

--- a/.github/workflows/CI-release-manually.yml
+++ b/.github/workflows/CI-release-manually.yml
@@ -1,0 +1,32 @@
+name: Create Release
+
+run-name: "Create a release : manually triggerable"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_name:
+        description: "The release name"
+        required: true
+        type: string
+      release_branch:
+        description: "Github branch name release can be created from"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run execution"
+        required: true
+        type: boolean
+        default: false
+jobs:
+  release:
+    name: Create artifacts and release them
+    uses: ./.github/workflows/CI-release.yml
+    with:
+      release_name: ${{ inputs.release_name }}
+      release_branch: ${{ inputs.release_branch }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+      RELEASES_PROD_SLACK_WEBHOOK_URL: ${{ secrets.RELEASES_PROD_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/CI-release.yml
+++ b/.github/workflows/CI-release.yml
@@ -1,14 +1,23 @@
 name: Docker image build and publish
 
-run-name: "Workflow CI/CD Steps: Docker image build and publish"
+run-name: "Workflow Release Steps: build docker images, publish them, create release and notify on slack"
 
 on:
   workflow_call:
     inputs:
+      release_name:
+        description: "The release name"
+        required: true
+        type: string
       release_branch:
         description: "Github branch name release can be created from"
         required: true
         type: string
+      dry_run:
+        description: "Dry run execution"
+        required: true
+        type: boolean
+        default: false
     secrets:
       DOCKER_HUB_USERNAME:
         required: true
@@ -36,6 +45,29 @@ jobs:
           ref: ${{ github.ref }}
           docker_hub_org: ${{ env.DOCKER_HUB_ORG }}
           docker_image_name: ${{ env.DOCKER_IMAGE_BUILD_NAME }}
+          dry_run: ${{ inputs.dry_run }}
+
+    outputs:
+      artifact_name: ${{ steps.build-docker-image.outputs.artifact_name }}
+
+  build-docker-fastruntime:
+    runs-on: warp-ubuntu-latest-x64-8x
+    name: Build Docker Image relay with fast-runtime
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Docker build
+        id: build-docker-image
+        uses: ./.github/actions/build-docker-image
+        with:
+          ref: ${{ github.ref }}
+          profile: release
+          docker_image_suffix: '-fastruntime'
+          features: fast-runtime
+          docker_hub_org: ${{ env.DOCKER_HUB_ORG }}
+          docker_image_name: ${{ env.DOCKER_IMAGE_BUILD_NAME }}
+          dry_run: ${{ inputs.dry_run }}
 
     outputs:
       artifact_name: ${{ steps.build-docker-image.outputs.artifact_name }}
@@ -65,6 +97,7 @@ jobs:
           DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
         shell: bash
         run: |
+          export DRY_RUN=${{ inputs.dry_run }}
           # shellcheck disable=SC1090
           source "${GITHUB_WORKSPACE}/ci/setup_env.sh"
           "${GITHUB_WORKSPACE}/ci/publish-docker-image.sh" --image-artifact ${{ needs.build-docker.outputs.artifact_name }}
@@ -77,7 +110,63 @@ jobs:
           retention-days: 7
           overwrite: true
 
+  publish-docker-image-fastruntime:
+    runs-on: warp-ubuntu-latest-x64-2x
+    name: Publish Docker Image relay fast-runtime
+    needs: [ build-docker-fastruntime ]
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Download zkVerify Docker image fastruntime artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-docker-fastruntime.outputs.artifact_name }}
+          path: ./
+
+      - name: Publish fast-runtime Docker image(s)
+        env:
+          RELEASE_BRANCH: ${{ inputs.release_branch }}
+          MAINTAINERS_KEYS: ${{ vars.MAINTAINERS_KEYS }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+        shell: bash
+        run: |
+          export DRY_RUN=${{ inputs.dry_run }}
+          export FAST_RUNTIME_RELEASE="true"
+          # shellcheck disable=SC1090
+          source "${GITHUB_WORKSPACE}/ci/setup_env.sh"
+          "${GITHUB_WORKSPACE}/ci/publish-docker-image.sh" --image-artifact ${{ needs.build-docker-fastruntime.outputs.artifact_name }}
+
+  release:
+    runs-on: warp-ubuntu-latest-x64-2x
+    name: Create release
+    needs: [ publish-docker-image, publish-docker-image-fastruntime ]
+    steps:
+      - name: Retrieve saved runtime wasm
+        uses: actions/download-artifact@v4
+        with:
+          name: "zkv_runtime.relay.compact.compressed.wasm"
+          path: wasm
+
+      - name: Create Release
+        id: create-release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ inputs.release_name }}
+          generate_release_notes: true
+          draft: ${{ inputs.dry_run }}
+          prerelease: false
+          files: |
+            wasm/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Notify Slack Production Releases
+        if: ${{ inputs.dry_run == false }}
         uses: slackapi/slack-github-action@v1.25.0
         with:
           payload: |

--- a/.github/workflows/CI-tag-orchestrator.yml
+++ b/.github/workflows/CI-tag-orchestrator.yml
@@ -1,19 +1,17 @@
 name: Tag-orchestrator
-
 on:
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+-[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
-  docker-image:
-    name: Docker image
-    strategy:
-      fail-fast: false
-
-    uses: ./.github/workflows/CI-docker-build-publish.yml
+  release:
+    name: Create artifacts and release them
+    uses: ./.github/workflows/CI-release.yml
     with:
+      release_name: "Release ${{ github.ref_name }}"
       release_branch: release
+      dry_run: ${{ vars.TAG_RELEASE_DRY_RUN == 'true' }}
     secrets:
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -21,6 +21,7 @@ jobs:
           use_cache: 'yes'
           cache_key: 'unit-test'
           lld_install: 'yes'
+          skip_wasm_build: 'yes'
 
       - name: Cargo unit test runtime without features
         uses: ./.github/actions/cmd-in-docker
@@ -29,6 +30,7 @@ jobs:
           use_cache: 'yes'
           cache_key: 'unit-test'
           lld_install: 'yes'
+          skip_wasm_build: 'yes'
 
       - name: Upload unit test output
         if: ${{ !cancelled() }}

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - "NODEJS_VERSION_INSTALL=${NODEJS_VERSION_INSTALL:-}"
       - "CMAKE_INSTALL=${CMAKE_INSTALL:-}"
       - "LLD_INSTALL=${LLD_INSTALL:-}"
+      - "SKIP_WASM_BUILD=${SKIP_WASM_BUILD:-}"
       - "LOCAL_USER_ID=${USER_ID:-}"
       - "LOCAL_GRP_ID=${GRP_ID:-}"
     entrypoint: ${DOCKER_BUILD_DIR}/ci/entrypoint.sh

--- a/ci/entrypoint.sh
+++ b/ci/entrypoint.sh
@@ -11,6 +11,7 @@ CARGO_BINARIES_INSTALL="${CARGO_BINARIES_INSTALL:-}"
 NODEJS_VERSION_INSTALL="${NODEJS_VERSION_INSTALL:-}"
 CMAKE_INSTALL="${CMAKE_INSTALL:-}"
 LLD_INSTALL="${LLD_INSTALL:-}"
+SKIP_WASM_BUILD="${SKIP_WASM_BUILD:-}"
 TARGET_DIR="${DOCKER_BUILD_DIR}/target"
 
 fn_die() {
@@ -106,6 +107,11 @@ export DONT_CACHE_NATIVE="true"
 # then the compiled artifact (cargo use timestamp to identify what to recompile). So we can
 # save 20/30% time on disable it without to lose any advantage.
 export CARGO_INCREMENTAL=0
+
+# If SKIP_WASM_BUILD is set, we export the variable to skip the runtime wasm build
+if [ -n "${SKIP_WASM_BUILD}" ]; then
+  export SKIP_WASM_BUILD=1
+fi
 
 # Run
 if [ "$USERNAME" = "root" ]; then


### PR DESCRIPTION
Create release CI step.

Bonus:
- add runtime wasm artifact to the release
- build and deploy fast-runtime docker image (just latest)
- dry run execution on docker images
- Introduced the skip wasm build option where is possible
- Manually triggerable