### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -41,7 +41,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ inputs.ref }}
         fetch-depth: 0

--- a/.github/workflows/CI-audit.yml
+++ b/.github/workflows/CI-audit.yml
@@ -14,7 +14,7 @@ jobs:
     name: Cargo audit
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cargo audit
         uses: ./.github/actions/cmd-in-docker

--- a/.github/workflows/CI-build-docker-image-manually.yml
+++ b/.github/workflows/CI-build-docker-image-manually.yml
@@ -34,7 +34,7 @@ jobs:
     name: Build Docker image Manually
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker build
         id: build-docker-image

--- a/.github/workflows/CI-build-docker-image.yml
+++ b/.github/workflows/CI-build-docker-image.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build Docker image
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker build
         id: build-docker-image

--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build relay chain and paratest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Relay chain and paratest build
         uses: ./.github/actions/cmd-in-docker

--- a/.github/workflows/CI-check-lockfile.yml
+++ b/.github/workflows/CI-check-lockfile.yml
@@ -12,7 +12,7 @@ jobs:
     name: Check lockfile
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check lockfile
         uses: ./.github/actions/cmd-in-docker

--- a/.github/workflows/CI-coverage.yml
+++ b/.github/workflows/CI-coverage.yml
@@ -12,7 +12,7 @@ jobs:
     name: Coverage
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cargo coverage
         uses: ./.github/actions/cmd-in-docker

--- a/.github/workflows/CI-feature-propagation.yml
+++ b/.github/workflows/CI-feature-propagation.yml
@@ -12,7 +12,7 @@ jobs:
     name: Feature propagation
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Features
         uses: ./.github/actions/cmd-in-docker

--- a/.github/workflows/CI-lint-format.yml
+++ b/.github/workflows/CI-lint-format.yml
@@ -12,7 +12,7 @@ jobs:
     name: Lint and format
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cargo lint
         uses: ./.github/actions/cmd-in-docker

--- a/.github/workflows/CI-release.yml
+++ b/.github/workflows/CI-release.yml
@@ -36,7 +36,7 @@ jobs:
     name: Build Docker Image relay
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker build
         id: build-docker-image
@@ -55,7 +55,7 @@ jobs:
     name: Build Docker Image relay with fast-runtime
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker build
         id: build-docker-image
@@ -78,7 +78,7 @@ jobs:
     needs: [build-docker]
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
@@ -116,7 +116,7 @@ jobs:
     needs: [ build-docker-fastruntime ]
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0

--- a/.github/workflows/CI-rustdoc.yml
+++ b/.github/workflows/CI-rustdoc.yml
@@ -27,7 +27,7 @@ jobs:
     name: Rustdoc generation
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Generate Rust documentation
         uses: ./.github/actions/cmd-in-docker

--- a/.github/workflows/CI-test-bench.yml
+++ b/.github/workflows/CI-test-bench.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build and run benchmarks
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: zkv build with runtime-benchmarks
         uses: ./.github/actions/cmd-in-docker

--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Cargo unit test
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cargo unit test
         uses: ./.github/actions/cmd-in-docker
@@ -46,7 +46,7 @@ jobs:
     name: Cargo integration test
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cargo integration test
         uses: ./.github/actions/cmd-in-docker

--- a/.github/workflows/CI-try-runtime.yml
+++ b/.github/workflows/CI-try-runtime.yml
@@ -24,7 +24,7 @@ jobs:
     name: Try runtime
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: zkv-runtime build
         uses: ./.github/actions/cmd-in-docker

--- a/.github/workflows/CI-udeps.yml
+++ b/.github/workflows/CI-udeps.yml
@@ -12,7 +12,7 @@ jobs:
     name: Udeps
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run cargo udeps
         uses: ./.github/actions/cmd-in-docker

--- a/.github/workflows/CI-zombienet-test.yml
+++ b/.github/workflows/CI-zombienet-test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Zombienet test
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download relay and paratest build binaries
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0