### PR TITLE
feat: add initial SuperNova pallet skeleton (no-std)

### DIFF
--- a/pallets/supernova-verifier/Cargo.toml
+++ b/pallets/supernova-verifier/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "supernova-verifier"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+nova-snark = "=0.41.0"
+ark-ff = { version = "=0.4.2", default-features = false, features=["serde"] }
+ark-ec = { version = "=0.4.2", default-features = false }
+ark-serialize = { version = "=0.4.2", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+    "nova-snark/std",
+    "ark-ff/std",
+    "ark-ec/std",
+    "ark-serialize/std",
+]

--- a/pallets/supernova-verifier/src/benchmarking.rs
+++ b/pallets/supernova-verifier/src/benchmarking.rs
@@ -1,0 +1,13 @@
+#![cfg(feature = "runtime-benchmarks")]
+
+use super::verifier;
+use frame_benchmarking::benchmarks;
+use frame_system::RawOrigin;
+
+benchmarks! {
+    verify {
+        let input: Vec<u8> = vec![]; // dummy proof
+    }: {
+        verifier::verify_proof(&input).ok();
+    }
+}

--- a/pallets/supernova-verifier/src/lib.rs
+++ b/pallets/supernova-verifier/src/lib.rs
@@ -1,0 +1,16 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! Minimal no-std SuperNova verifier module
+//!
+//! This will be extended later to pallet interface and runtime dispatchables.
+
+pub mod verifier {
+    use nova_snark::provider::ipa_pc::Evaluation; // example import
+    // use crate::... if you add types
+
+    /// Verify a proof (placeholder, to be ported with real logic)
+    pub fn verify_proof(_bytes: &[u8]) -> Result<bool, ()> {
+        // TODO: implement deserialization & call Nova verifier
+        Ok(true)
+    }
+}


### PR DESCRIPTION
This PR introduces the initial SuperNova verifier pallet as a no-std compatible skeleton, in preparation for full integration with the zkVerify runtime.

-   **Included**
        1. new folder pallets/supernova-verifier
        2. minimal no_std-compatible lib.rs exporting : pub fn verify_proof(&[u8]) -> Result<bool, ()>
        3. minimal Cargo.toml with : 
             1. nova-snark
             2. ark-ff, ark-ec, ark-serialize (default-features = false)
             3. feature gating (std / no_std)
         4. optional benchmarking.rs stub (runtime-benchmarks placeholder)
   

-   **Next Steps (follow-up PRs)**
         1. port CLI verifier logic to no_std implementation (reuse verify_proof)
         2. add ark-pallas / ark-vesta and implement proof deserialization
         3. expose pallet calls (dispatchable) to invoke verify_proof
         4. add tests (happy / unhappy path)
         5. update documentation (zkverify-docs)
  
Let me know if any preferred structure / naming conventions in the repo should be followed, happy to adjust in this PR.