### PR TITLE
fix: prevent overflow in delivery fee calculation

### DIFF
--- a/pallets/aggregate/src/data.rs
+++ b/pallets/aggregate/src/data.rs
@@ -219,7 +219,7 @@ impl<B: Debug + PartialEq> Delivery<B> {
     where
         B: Add<Output = B> + Clone,
     {
-        self.fee.clone() + self.owner_tip.clone()
+        self.fee.clone().saturating_add(self.owner_tip.clone())
     }
 }
 


### PR DESCRIPTION
Replace regular addition with saturating_add in Delivery::total_fee()

This is a security improvement that makes the fee calculation more robust and prevents potential DoS attacks through large balance manipulation.