### PR TITLE
Make clippy happy

### DIFF
--- a/verifiers/plonky2/src/resources.rs
+++ b/verifiers/plonky2/src/resources.rs
@@ -14,14 +14,6 @@
 // limitations under the License.
 
 #![cfg(any(test, feature = "runtime-benchmarks"))]
-pub struct MockConfig;
-
-impl crate::Config for MockConfig {
-    type MaxProofSize = frame_support::traits::ConstU32<1000000>;
-    type MaxPubsSize = frame_support::traits::ConstU32<1000000>;
-    type MaxVkSize = frame_support::traits::ConstU32<1000000>;
-    type WeightInfo = ();
-}
 
 pub struct TestData<T: crate::Config> {
     pub vk: crate::Vk<T>,

--- a/verifiers/plonky2/src/verifier_should.rs
+++ b/verifiers/plonky2/src/verifier_should.rs
@@ -20,6 +20,15 @@ use crate::resources::*;
 use frame_support::assert_ok;
 use rstest::*;
 
+pub struct MockConfig;
+
+impl crate::Config for MockConfig {
+    type MaxProofSize = frame_support::traits::ConstU32<1000000>;
+    type MaxPubsSize = frame_support::traits::ConstU32<1000000>;
+    type MaxVkSize = frame_support::traits::ConstU32<1000000>;
+    type WeightInfo = ();
+}
+
 #[fixture]
 fn worst_case_test_data() -> TestData<MockConfig> {
     get_parameterized_test_data(MAX_DEGREE_BITS, crate::vk::Plonky2Config::Poseidon)

--- a/verifiers/sp1/src/lib.rs
+++ b/verifiers/sp1/src/lib.rs
@@ -89,7 +89,7 @@ impl<T: Config> Verifier for Sp1<T> {
         *vk
     }
 
-    fn pubs_bytes(pubs: &Self::Pubs) -> Cow<[u8]> {
+    fn pubs_bytes(pubs: &Self::Pubs) -> Cow<'_, [u8]> {
         Cow::Borrowed(pubs)
     }
 }


### PR DESCRIPTION
A [lint introduced in Rust 1.89.0](https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint) is making CI fail. This PR fixes it.