### PR TITLE
chore(runtime): remove unused impl StakerData for (AccountId, Balance)

### DIFF
--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -115,17 +115,6 @@ impl StakerData for Box<dyn StakerData> {
     }
 }
 
-impl StakerData for (AccountId, Balance) {
-    fn staker_data(&self) -> (AccountId, AccountId, Balance, StakerStatus<AccountId>) {
-        (
-            self.0.clone(),
-            self.0.clone(),
-            self.1,
-            StakerStatus::Validator,
-        )
-    }
-}
-
 /// Configure initial storage state for FRAME modules.
 #[allow(clippy::too_many_arguments)]
 fn genesis(


### PR DESCRIPTION
Remove an unused tuple implementation of StakerData to reduce ambiguity and keep the genesis presets explicit. The boxed trait impl remains to support stakers.iter().map(StakerData::staker_data).