### PR TITLE
Fix cargo audit: update rustls-webpki and triage RUSTSEC-2026-0049

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -50,6 +50,15 @@ ignore = [
     # Nothing in the workspace actually depends on this chain (`cargo tree` confirms it).
     # It remains in Cargo.lock because Cargo resolves optional dependencies in the lockfile
     # (libp2p's optional `quic` feature pulls it in). Cannot be updated: no patched 0.10.x exists.
+    "RUSTSEC-2026-0049", # rustls-webpki v0.101.7 and v0.102.8 — CRL distribution point matching bug.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0049 ->
+    # https://github.com/rustls/webpki/security/advisories/GHSA-pwjx-qhcg-rvj4
+    # The vulnerability only affects TLS CRL-based certificate revocation checking, which is opt-in
+    # in rustls (requires explicitly calling `.with_crls()`). We never configure CRL revocation
+    # checking — the vulnerable code path is never reached. The v0.103.9 instance was updated to
+    # v0.103.10; the 0.101.x and 0.102.x versions are transitive deps from polkadot-sdk
+    # (libp2p-websocket -> rustls 0.21, jsonrpsee -> rustls 0.22) with no patched versions
+    # in those major lines.
 ]
 informational_warnings = ["unmaintained", "yanked"]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3113,7 +3113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -13494,7 +13494,7 @@ dependencies = [
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -13599,7 +13599,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
@@ -13635,9 +13635,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring 0.17.14",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Update `rustls-webpki` 0.103.9 → 0.103.10 (patched version) via `cargo update`
- Add motivated ignore for `RUSTSEC-2026-0049` covering `rustls-webpki` 0.101.7 and 0.102.8 — transitive polkadot-sdk deps (libp2p-websocket → rustls 0.21, jsonrpsee → rustls 0.22) with no patched versions in those major lines
- The vulnerability only affects opt-in TLS CRL revocation checking (`.with_crls()`), which we never configure — the vulnerable code path is never reached

## Test plan
- [x] `cargo audit` passes with 0 vulnerabilities (only informational warnings remain)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)