### PR TITLE
Add Legacy variant to ultrahonk verifier for backward-compatible statement hashes

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -144,6 +144,25 @@ ignore = [
     # compiled out and the unsound aliased mutable reference can never be constructed.
     # rand 0.8.5 has no patched 0.8.x release; it is a transitive dep from arkworks
     # (ark-std), polkadot-sdk, plonky2, and sp1, none of which have moved to rand ≥0.9.
+    #
+    # ── May 2026 batch: hickory-proto via polkadot-sdk networking ──
+    #
+    "RUSTSEC-2026-0119", # hickory-proto v0.24.4 and v0.25.2 — O(n²) CPU exhaustion in DNS message encoding.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0119 ->
+    # https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-q2qq-hmj6-3wpp
+    # MODERATE severity DoS via crafted DNS messages with many records triggering quadratic name
+    # compression. v0.24.4 comes from libp2p-dns -> hickory-resolver (polkadot-sdk via
+    # sc-telemetry -> libp2p 0.54.1). v0.25.2 comes from litep2p -> hickory-resolver
+    # (polkadot-sdk via sc-network -> litep2p 0.9.5). Fix is in 0.26.1; no patched 0.24.x or
+    # 0.25.x exists, and parent crates are pinned by polkadot-sdk stable2412.
+    "RUSTSEC-2026-0118", # hickory-proto v0.25.2 — NSEC3 closest-encloser proof validation unbounded loop.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0118 ->
+    # https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-3v94-mw7p-v465
+    # HIGH severity DoS affecting DNSSEC validation. Requires `DnssecDnsHandle` with
+    # `dnssec-ring` or `dnssec-aws-lc-rs` feature enabled. In our build, hickory-proto 0.25.2
+    # has only `futures-io` and `std` features enabled — no DNSSEC features are active
+    # (`cargo tree -p hickory-proto@0.25.2 -e features` confirms this). The DNSSEC validation
+    # code is not compiled, so the vulnerable code path is unreachable. Unaffected.
 ]
 informational_warnings = ["unmaintained", "yanked"]
 

--- a/rpc/vk_hash/src/lib.rs
+++ b/rpc/vk_hash/src/lib.rs
@@ -127,6 +127,8 @@ pub enum UltrahonkVk {
     V0_84(Bytes),
     #[serde(alias = "v30")]
     V3_0(Bytes),
+    #[serde(alias = "legacy")]
+    Legacy(Bytes),
 }
 
 impl TryFrom<UltrahonkVk> for UltrahonkVersionedVk {
@@ -147,6 +149,13 @@ impl TryFrom<UltrahonkVk> for UltrahonkVersionedVk {
                     .try_into()
                     .map_err(|_| "Incorrect length for V3_0 VK")?;
                 Ok(UltrahonkVersionedVk::V3_0(arr))
+            }
+            UltrahonkVk::Legacy(bytes) => {
+                let arr = bytes
+                    .0
+                    .try_into()
+                    .map_err(|_| "Incorrect length for Legacy VK")?;
+                Ok(UltrahonkVersionedVk::Legacy(arr))
             }
         }
     }

--- a/verifiers/ultrahonk/src/lib.rs
+++ b/verifiers/ultrahonk/src/lib.rs
@@ -95,6 +95,7 @@ impl TryFrom<Proof> for ultrahonk_no_std_v0_84::ProofType {
 pub enum ProtocolVersion {
     V0_84,
     V3_0,
+    Legacy,
 }
 
 impl From<&VersionedProof> for ProtocolVersion {
@@ -102,6 +103,7 @@ impl From<&VersionedProof> for ProtocolVersion {
         match value {
             VersionedProof::V0_84(_) => ProtocolVersion::V0_84,
             VersionedProof::V3_0(_) => ProtocolVersion::V3_0,
+            VersionedProof::Legacy(_) => ProtocolVersion::Legacy,
         }
     }
 }
@@ -116,6 +118,8 @@ pub enum VersionedProof {
     V0_84(Proof),
     #[codec(index = 1)]
     V3_0(Proof),
+    #[codec(index = 2)]
+    Legacy(Proof),
 }
 
 // Important Notes:
@@ -128,6 +132,8 @@ pub enum VersionedVk {
     V0_84([u8; VK_SIZE_V0_84]),
     #[codec(index = 1)]
     V3_0([u8; VK_SIZE_V3_0]),
+    #[codec(index = 2)]
+    Legacy([u8; VK_SIZE_V0_84]),
 }
 
 impl Proof {
@@ -245,7 +251,8 @@ impl<T: Config> Verifier for Ultrahonk<T> {
         );
 
         match (proof, vk) {
-            (VersionedProof::V0_84(inner_proof), VersionedVk::V0_84(vk_bytes)) => {
+            (VersionedProof::V0_84(inner_proof), VersionedVk::V0_84(vk_bytes))
+            | (VersionedProof::Legacy(inner_proof), VersionedVk::Legacy(vk_bytes)) => {
                 // Transform input proof into an UltraHonk verifier-compatible proof
                 let prepared: ultrahonk_no_std_v0_84::ProofType = inner_proof.clone().try_into()?;
 
@@ -278,11 +285,11 @@ impl<T: Config> Verifier for Ultrahonk<T> {
 
     fn validate_vk(vk: &Self::Vk) -> Result<(), VerifyError> {
         let vk_bytes: &[u8] = match vk {
-            VersionedVk::V0_84(vk_bytes) => vk_bytes,
+            VersionedVk::V0_84(vk_bytes) | VersionedVk::Legacy(vk_bytes) => vk_bytes,
             VersionedVk::V3_0(vk_bytes) => vk_bytes,
         };
         match vk {
-            VersionedVk::V0_84(_) => {
+            VersionedVk::V0_84(_) | VersionedVk::Legacy(_) => {
                 let _vk = ultrahonk_no_std_v0_84::key::VerificationKey::<CurveHooksImpl>::try_from(
                     vk_bytes,
                 )
@@ -301,6 +308,24 @@ impl<T: Config> Verifier for Ultrahonk<T> {
         Ok(())
     }
 
+    fn vk_hash(vk: &Self::Vk) -> H256 {
+        match vk {
+            // Legacy uses SHA2-256 of raw VK bytes to match the pre-versioning hash.
+            // See commit 113a728c, verifiers/ultrahonk/src/lib.rs:183-184
+            VersionedVk::Legacy(_) => sp_io::hashing::sha2_256(&Self::vk_bytes(vk)).into(),
+            _ => sp_io::hashing::keccak_256(&Self::vk_bytes(vk)).into(),
+        }
+    }
+
+    fn vk_bytes(vk: &Self::Vk) -> Cow<'_, [u8]> {
+        match vk {
+            // Legacy returns raw bytes (no enum prefix) to match the pre-versioning encoding.
+            // See commit 113a728c, verifiers/ultrahonk/src/lib.rs:187-188,202-204
+            VersionedVk::Legacy(bytes) => Cow::Owned(bytes.to_vec()),
+            _ => Cow::Owned(vk.encode()),
+        }
+    }
+
     fn pubs_bytes(pubs: &Self::Pubs) -> Cow<'_, [u8]> {
         let data = pubs
             .iter()
@@ -311,15 +336,17 @@ impl<T: Config> Verifier for Ultrahonk<T> {
 
     fn verifier_version_hash(proof: &Self::Proof) -> H256 {
         // Computed as: SHA2-256("ultrahonk:vx.y")
-        let h = match proof {
-            VersionedProof::V0_84(_) => hex_literal::hex!(
+        match proof {
+            VersionedProof::V0_84(_) => H256(hex_literal::hex!(
                 "4966cd7801ae9ef9d7afb52ec3de92f0693e720f58c5c8ecfb23d85b0934f018"
-            ),
-            VersionedProof::V3_0(_) => hex_literal::hex!(
+            )),
+            VersionedProof::V3_0(_) => H256(hex_literal::hex!(
                 "55b52ad2b4153c872e27d688f567c1406f0d93b5528dd2b0bf2a9a40df97f1f9"
-            ),
-        };
-        H256(h)
+            )),
+            // Legacy returns NO_VERSION_HASH to preserve backward compatibility with
+            // the pre-versioning statement hash (before commit 83e40f29).
+            VersionedProof::Legacy(_) => pallet_verifiers::traits::NO_VERSION_HASH,
+        }
     }
 }
 
@@ -368,11 +395,13 @@ impl<T: Config, W: WeightInfo> pallet_verifiers::WeightInfo<Ultrahonk<T>> for Ul
         _pubs: &<Ultrahonk<T> as Verifier>::Pubs,
     ) -> Weight {
         match proof {
-            VersionedProof::V0_84(inner) => match ProofType::from(inner) {
-                // For V0.84, we conservatively charge the maximum (worst case = 25)
-                ProofType::ZK => T::WeightInfo::verify_zk_proof_v0_84(),
-                ProofType::Plain => T::WeightInfo::verify_plain_proof_v0_84(),
-            },
+            VersionedProof::V0_84(inner) | VersionedProof::Legacy(inner) => {
+                match ProofType::from(inner) {
+                    // For V0.84/Legacy, we conservatively charge the maximum (worst case = 25)
+                    ProofType::ZK => T::WeightInfo::verify_zk_proof_v0_84(),
+                    ProofType::Plain => T::WeightInfo::verify_plain_proof_v0_84(),
+                }
+            }
             VersionedProof::V3_0(inner) => {
                 // For V3.0: weight is parameterized by log_circuit_size.
                 // We conservatively charge the maximum (worst case = 25)

--- a/verifiers/ultrahonk/src/resources.rs
+++ b/verifiers/ultrahonk/src/resources.rs
@@ -48,6 +48,15 @@ impl TestParams {
             protocol_version: ProtocolVersion::V0_84,
         }
     }
+
+    // For handling Legacy (same data as V0_84, different version wrapping)
+    pub fn new_legacy(proof_type: ProofType) -> Self {
+        Self {
+            log_circuit_size: None,
+            proof_type,
+            protocol_version: ProtocolVersion::Legacy,
+        }
+    }
 }
 
 pub struct TestData {
@@ -92,7 +101,7 @@ pub fn get_parameterized_test_data(test_params: TestParams) -> Result<TestData, 
                 pubs,
             })
         }
-        ProtocolVersion::V0_84 => {
+        ProtocolVersion::V0_84 | ProtocolVersion::Legacy => {
             let raw_test_data = match test_params.proof_type {
                 ProofType::ZK => &DATA_V0_84_ZK,
                 ProofType::Plain => &DATA_V0_84_PLAIN,
@@ -102,9 +111,17 @@ pub fn get_parameterized_test_data(test_params: TestParams) -> Result<TestData, 
                 .vk
                 .try_into()
                 .expect("Benchmark file should always have the correct vk size");
-            let versioned_vk = VersionedVk::V0_84(raw_vk);
             let proof = crate::Proof::new(test_params.proof_type, raw_test_data.proof.to_vec());
-            let versioned_proof = crate::VersionedProof::V0_84(proof);
+            let (versioned_vk, versioned_proof) = match test_params.protocol_version {
+                ProtocolVersion::Legacy => (
+                    VersionedVk::Legacy(raw_vk),
+                    crate::VersionedProof::Legacy(proof),
+                ),
+                _ => (
+                    VersionedVk::V0_84(raw_vk),
+                    crate::VersionedProof::V0_84(proof),
+                ),
+            };
             let pubs = raw_test_data
                 .pubs
                 .chunks_exact(crate::PUB_SIZE)

--- a/verifiers/ultrahonk/src/verifier_should.rs
+++ b/verifiers/ultrahonk/src/verifier_should.rs
@@ -46,6 +46,7 @@ fn load_test_data(proof_type: ProofType, version: ProtocolVersion) -> TestData {
             TestParams::new(MAX_BENCHMARKED_LOG_CIRCUIT_SIZE, proof_type, version)
         }
         ProtocolVersion::V0_84 => TestParams::new_v0_84(proof_type),
+        ProtocolVersion::Legacy => TestParams::new_legacy(proof_type),
     };
     get_parameterized_test_data(test_params).expect("test data should be present")
 }
@@ -68,6 +69,12 @@ fn mutate_proof_bytes(
             mutator(&mut raw);
             VersionedProof::V3_0(Proof::new(pt, raw))
         }
+        VersionedProof::Legacy(proof) => {
+            let pt = ProofType::from(&proof);
+            let mut raw: RawProof = proof.into();
+            mutator(&mut raw);
+            VersionedProof::Legacy(Proof::new(pt, raw))
+        }
     }
 }
 
@@ -88,6 +95,11 @@ fn mutate_proof_bytes_with_type(
             mutator(&mut raw);
             VersionedProof::V3_0(Proof::new(new_type, raw))
         }
+        VersionedProof::Legacy(proof) => {
+            let mut raw: RawProof = proof.into();
+            mutator(&mut raw);
+            VersionedProof::Legacy(Proof::new(new_type, raw))
+        }
     }
 }
 
@@ -102,13 +114,18 @@ fn mutate_vk_bytes(versioned_vk: VersionedVk, mutator: impl FnOnce(&mut [u8])) -
             mutator(&mut vk);
             VersionedVk::V3_0(vk)
         }
+        VersionedVk::Legacy(mut vk) => {
+            mutator(&mut vk);
+            VersionedVk::Legacy(vk)
+        }
     }
 }
 
 #[rstest]
 fn verify_valid_proof(
     #[values(ProofType::ZK, ProofType::Plain)] proof_type: ProofType,
-    #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84)] version: ProtocolVersion,
+    #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84, ProtocolVersion::Legacy)]
+    version: ProtocolVersion,
 ) {
     let TestData {
         versioned_vk,
@@ -128,6 +145,12 @@ fn verify_valid_proof(
     ProtocolVersion::V3_0,
     hex!("22af324f6deda316ee8b2d91cea110dbbf67715caed46b2f953a91725b8032bc"),
 )]
+#[case::legacy(
+    ProtocolVersion::Legacy,
+    // Legacy VK hash: SHA2-256 of raw VK bytes (matching pre-versioning code at
+    // commit 113a728c, verifiers/ultrahonk/src/lib.rs:183-184)
+    hex!("f28c8c634872785e7c6ae10684b7952f9d4822d065cee182489d5e49c995080d"),
+)]
 fn verify_vk_hash(#[case] version: ProtocolVersion, #[case] expected: [u8; 32]) {
     let TestData { versioned_vk, .. } = load_test_data(ProofType::Plain, version);
 
@@ -141,7 +164,8 @@ mod reject {
 
     #[rstest]
     fn invalid_public_values(
-        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84)] version: ProtocolVersion,
+        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84, ProtocolVersion::Legacy)]
+        version: ProtocolVersion,
     ) {
         let TestData {
             versioned_vk,
@@ -161,7 +185,8 @@ mod reject {
     #[rstest]
     fn proof_with_one_invalid_public_input(
         #[values(ProofType::ZK, ProofType::Plain)] proof_type: ProofType,
-        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84)] version: ProtocolVersion,
+        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84, ProtocolVersion::Legacy)]
+        version: ProtocolVersion,
     ) {
         let TestData {
             versioned_vk,
@@ -180,7 +205,8 @@ mod reject {
     #[rstest]
     fn too_many_public_inputs(
         #[values(ProofType::ZK, ProofType::Plain)] proof_type: ProofType,
-        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84)] version: ProtocolVersion,
+        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84, ProtocolVersion::Legacy)]
+        version: ProtocolVersion,
     ) {
         let TestData {
             versioned_vk,
@@ -200,7 +226,8 @@ mod reject {
 
     #[rstest]
     fn invalid_number_of_public_inputs(
-        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84)] version: ProtocolVersion,
+        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84, ProtocolVersion::Legacy)]
+        version: ProtocolVersion,
     ) {
         let TestData {
             versioned_vk,
@@ -222,7 +249,8 @@ mod reject {
 
     #[rstest]
     fn invalid_zk_proof(
-        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84)] version: ProtocolVersion,
+        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84, ProtocolVersion::Legacy)]
+        version: ProtocolVersion,
     ) {
         let TestData {
             versioned_vk,
@@ -243,7 +271,8 @@ mod reject {
 
     #[rstest]
     fn invalid_plain_proof(
-        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84)] version: ProtocolVersion,
+        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84, ProtocolVersion::Legacy)]
+        version: ProtocolVersion,
     ) {
         let TestData {
             versioned_vk,
@@ -265,7 +294,8 @@ mod reject {
     #[rstest]
     fn oversized_proof(
         #[values(ProofType::ZK, ProofType::Plain)] proof_type: ProofType,
-        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84)] version: ProtocolVersion,
+        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84, ProtocolVersion::Legacy)]
+        version: ProtocolVersion,
     ) {
         let TestData {
             versioned_vk,
@@ -284,7 +314,8 @@ mod reject {
     #[rstest]
     fn undersized_proof(
         #[values(ProofType::ZK, ProofType::Plain)] proof_type: ProofType,
-        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84)] version: ProtocolVersion,
+        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84, ProtocolVersion::Legacy)]
+        version: ProtocolVersion,
     ) {
         let TestData {
             versioned_vk,
@@ -304,7 +335,8 @@ mod reject {
 
     #[rstest]
     fn invalid_vk(
-        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84)] version: ProtocolVersion,
+        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84, ProtocolVersion::Legacy)]
+        version: ProtocolVersion,
     ) {
         let TestData {
             versioned_vk,
@@ -334,10 +366,47 @@ mod reject {
         );
     }
 
+    #[test]
+    fn legacy_proof_with_v0_84_vk() {
+        let TestData {
+            versioned_vk, pubs, ..
+        } = load_test_data(ProofType::ZK, ProtocolVersion::V0_84);
+
+        let TestData {
+            versioned_proof: legacy_proof,
+            ..
+        } = load_test_data(ProofType::ZK, ProtocolVersion::Legacy);
+
+        assert_eq!(
+            Ultrahonk::<MockRuntime>::verify_proof(&versioned_vk, &legacy_proof, &pubs),
+            Err(VerifyError::VerifyError)
+        );
+    }
+
+    #[test]
+    fn v0_84_proof_with_legacy_vk() {
+        let TestData {
+            versioned_vk: legacy_vk,
+            pubs,
+            ..
+        } = load_test_data(ProofType::ZK, ProtocolVersion::Legacy);
+
+        let TestData {
+            versioned_proof: v0_84_proof,
+            ..
+        } = load_test_data(ProofType::ZK, ProtocolVersion::V0_84);
+
+        assert_eq!(
+            Ultrahonk::<MockRuntime>::verify_proof(&legacy_vk, &v0_84_proof, &pubs),
+            Err(VerifyError::VerifyError)
+        );
+    }
+
     #[rstest]
     fn malformed_proof(
         #[values(ProofType::ZK, ProofType::Plain)] proof_type: ProofType,
-        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84)] version: ProtocolVersion,
+        #[values(ProtocolVersion::V3_0, ProtocolVersion::V0_84, ProtocolVersion::Legacy)]
+        version: ProtocolVersion,
     ) {
         let TestData {
             versioned_vk,
@@ -352,4 +421,128 @@ mod reject {
             Err(VerifyError::VerifyError)
         );
     }
+}
+
+/// Regression test: verify that the Legacy variant produces the same statement hash as the
+/// pre-versioning code. Uses the exact same test data from before commit 83e40f29:
+///   - VALID_VK: commit 113a728c, verifiers/ultrahonk/src/resources.rs:968
+///   - public_input(): commit 113a728c, verifiers/ultrahonk/src/resources.rs:17-21
+///
+/// The pre-versioning code computed:
+///   - vk_hash: SHA2-256(raw_vk_bytes) (commit 113a728c, verifiers/ultrahonk/src/lib.rs:183-184)
+///   - vk_bytes: raw bytes via to_vec() (commit 113a728c, verifiers/ultrahonk/src/lib.rs:202-204)
+///   - verifier_version_hash: NO_VERSION_HASH (default trait impl)
+///   - hash_context_data: b"ultrahonk"
+///   - pubs_bytes: flat concatenation of public inputs
+///
+/// Statement hash formula (pallets/verifiers/src/lib.rs:192-211):
+///   keccak256(keccak256(context) || vk_hash || verifier_version_hash || keccak256(pubs_bytes))
+#[test]
+fn legacy_produces_old_statement_hash() {
+    // VALID_VK from commit 113a728c, verifiers/ultrahonk/src/resources.rs:968
+    let raw_vk = hex!(
+        "
+        0000000000000020000000000000000500000000000000020000000000000001
+        1d4e2b662cf75598ae75c80cb6190d6d86bc92fd69f1420fc9e6d5be8ba09e2c
+        30210ded34398f54e3048f65c3f1dac749cc5022828668a6b345712af7369cbb
+        1c3736f27bc34afe8eb1021704555717e76024100c144933330df5d9a6fb7e7f
+        215612b168ecf42291b6df40da24069d5a0d5f2599d8be1ec34c5095e0922151
+        059aecd0bba76edd4de929d587575b50c50f4be99a4615bfbd4ece89cb1442f1
+        121b12b8bfa67425811621a1be826bcc5add41edb51fdce6c134c8e3ff5b1578
+        2ad6f88dd8a25590c065ad43adb6f3d4ccba5a7312f27dd564b12325a2594ae5
+        038c0c60a3dfed43a24eefcc0331f08074bea7bb5c7f65191ec2c3fe59a239cc
+        17bebc96661564acc3f5c59647e9270570e0c238916df6390c8590445f256d1d
+        0bf23741444a9bf150d33f19d70a31863256e71d2bb1adf96b04d61f2c95a2c4
+        1b8058db3a5b9890b24d2545b7dd4aca37844bb0964691811a3dfe7b9fd24f8f
+        28362861904e4b69161d7f43201c9213ede6e74eb63800123b82c73ad0156c40
+        3058b7f62cbcbdc8763b05935e9965bea86cd205281d331fb426ef4232ffe5c5
+        2b312f13fea65176bc0fe06aef8724f256898d215c78835f40bfe56fbf3f0de3
+        0ac6c48b063b744bbeecb29c8962cf27853ae788601a92a0420ba047a7f7a643
+        265a8af9070f8bd5e18bc97a13c985d35a59c188d3d5ee626bbc4589bba9ff9f
+        024236bda126650fb5228cf424a0878775499e69e8bd2c39af33bd5fa0b4079a
+        233cda9292be02cfa2da9d0fc7b0eab0eb1a867b06854066589b967455259b32
+        0ca0bc4b1cd9eadbbf49eae56a99a4502ef13d965226a634d0981555e4a4da56
+        1a8a818e6c61f68cefa329f2fabc95c80ad56a538d852f75eda858ed1a616c74
+        09dfd2992ac1708f0dd1d28c2ad910d9cf21a1510948580f406bc9416113d620
+        205f76eebda12f565c98c775c4e4f3534b5dcc29e57eed899b1a1a880534dcb9
+        1b8afad764d2cbe67c94249535bba7fcbd3f412f868487222aa54f3268ab64a2
+        01b70a90a334c9bd5096aad8a0cc5d4c1d1cdb0fe415445bd0c84309caaf213e
+        13240f97a584b45184c8ec31319b5f6c04ee19ec1dfec87ed47d6d04aa158de2
+        2dad22022121d689f57fb38ca21349cefb5d240b07ceb4be26ea429b6dc9d9e0
+        2dbea5caeded6749d2ef2e2074dbea56c8d54fa043a54c6e6a40238fb0a52c8e
+        1f299b74e3867e8c8bc149ef3a308007a3bd6f9935088ec247cce992c33a5336
+        06652c2a72cb81284b190e235ee029a9463f36b2e29a1775c984b9d9b2714bab
+        268e8d1e619fde85a71e430b77974326d790cb64c87558085332df639b8ce410
+        2849ce9f77669190ed63388b3cc4a6d4e0d895c683ae0057f36a00e62416de5e
+        2f8d58d08d4b4bb3a63e23e091e7a1f13c581c8a98c75014d5ec8a20890c62a5
+        0fff3b4e49a2e6e05bc63d8438368182639ef435c89f30e3a3a9053d97bea5f2
+        1820cafe7ffbef14880565ed976d53ed31c844187447d21f09100e8e569d3aec
+        2e89eeb660cac820de50be4c53b608dd67c6977f5f1746fcf0fb6475d81ccd93
+        18ca593957d2677420236138b3659a6b95b580bcc09a3dfbdadfa58a38222c15
+        0c756ba6a0c66b05655349f04c61dff94dddf3a4d0117fafda741f9518c42f00
+        0f87a1201ebad9bd23fed33824ae4ba2a1a307a45fb15594f8d553d2ebf9c285
+        248460656ec9bc0ad940051e3b0751d25bb97885d8bc362eb06b96ea78d82f84
+        0a5eebc538dc40185864706e22d850e3c02ce38e325761a59132bdb9e9d795be
+        161edd8773a3b74c0553b690b4b80b2a5cbd4a1a25fda097bef23e349531b43e
+        287139da895215c216aebe8cce7d3b944f4a3b051bd407126007921cb1fbc5fc
+        20d671263cad88c119d0a5d172679309087e385f8e76d4cfa834fab61ebd6603
+        0f9e6dfd3e6f4584b28e2cb00483dc2ffd9bf5f7ae2cc3f1ea0869c5ae71d9a1
+        101e267b586089a8bb447e83ab3b7029ed788cc214e0be44485e2f39afbb7ae6
+        13410d68bce429dc36e23023cfe21c5f2ced7e136529a4bcd4317232f2fc16b6
+        1054a26ae3aeeeedc653cf5c5e3c09e2258141e67f4a5a48b50cbf48958b40bd
+        2d14190edcf9b2aa697b677c779083aaf0151cc4f673dcf4bdba392d6280e376
+        2e9e762a66fed77eb0e72645e5ba54f32c1d1bfbc4bd862361dafd7ebd6c68dd
+        0b4a012fbc876f57da669215383f3595383f787bca153e972e6cfb9dfebeaa1b
+        0000000000000000000000000000000000000000000000000000000000000001
+        0000000000000000000000000000000000000000000000000000000000000002
+        0af3884ecad3331429af995779c2602e93ca1ea976e9e1bc64bbcdbb9fe79212
+        1f18803add8ad686e13dc2a989dcfb010cb69b0b38200df51787b7104bc74fb6
+        "
+    );
+    let versioned_vk = VersionedVk::Legacy(raw_vk);
+
+    // VK hash must match verify_vk_hash() from commit 113a728c,
+    // verifiers/ultrahonk/src/verifier_should.rs:80-88
+    let vk_hash = Ultrahonk::<MockRuntime>::vk_hash(&versioned_vk);
+    assert_eq!(
+        vk_hash.as_bytes(),
+        hex!("862d96a25fb215e349e53f808e5cc5fff65c789f7a751c07857fdded9e3cbece"),
+    );
+
+    // public_input() from commit 113a728c, verifiers/ultrahonk/src/resources.rs:17-21
+    let pubs: Pubs = alloc::vec![
+        hex!("0000000000000000000000000000000000000000000000000000000000000002"),
+        hex!("0000000000000000000000000000000000000000000000000000000000000003"),
+    ];
+
+    // Proof bytes don't affect statement hash, only the Legacy variant matters
+    // (verifier_version_hash returns NO_VERSION_HASH for Legacy).
+    let versioned_proof = VersionedProof::Legacy(Proof::default());
+
+    let vk_or_hash = pallet_verifiers::VkOrHash::Vk(versioned_vk.into());
+    let statement_hash = pallet_verifiers::compute_statement_hash::<Ultrahonk<MockRuntime>>(
+        &vk_or_hash,
+        &versioned_proof,
+        &pubs,
+    );
+
+    // This is the same statement hash that the pre-versioning code would have produced
+    // with VALID_VK and public_input() test data.
+    assert_eq!(
+        statement_hash.as_bytes(),
+        &hex!("f0350931fcf99dcfb278b0b4e9752bef7bc22de05a822e220a3bc7013a90be72"),
+        "Legacy statement hash should match the pre-versioning statement hash"
+    );
+}
+
+#[test]
+fn legacy_verifier_version_hash_is_no_version_hash() {
+    let TestData {
+        versioned_proof, ..
+    } = load_test_data(ProofType::Plain, ProtocolVersion::Legacy);
+
+    assert_eq!(
+        Ultrahonk::<MockRuntime>::verifier_version_hash(&versioned_proof),
+        pallet_verifiers::traits::NO_VERSION_HASH,
+    );
 }

--- a/zombienet-tests/js_scripts/0012-aggregate_proofs.js
+++ b/zombienet-tests/js_scripts/0012-aggregate_proofs.js
@@ -31,6 +31,7 @@ const { PROOF: RISC0_V2_2_PROOF, PUBS: RISC0_V2_2_PUBS, VK: RISC0_V2_2_VK } = re
 const { PROOF: RISC0_V3_0_PROOF, PUBS: RISC0_V3_0_PUBS, VK: RISC0_V3_0_VK } = require('./risc0_v3_0_data.js');
 const { ZK_PROOF: ULTRAHONK_V0_84_ZK_PROOF, PLAIN_PROOF: ULTRAHONK_V0_84_PLAIN_PROOF, PUBS: ULTRAHONK_V0_84_PUBS, VK: ULTRAHONK_V0_84_VK } = require('./ultrahonk_v0_84_data.js');
 const { ZK_PROOF: ULTRAHONK_V3_0_ZK_PROOF, PLAIN_PROOF: ULTRAHONK_V3_0_PLAIN_PROOF, PUBS: ULTRAHONK_V3_0_PUBS, VK: ULTRAHONK_V3_0_VK } = require('./ultrahonk_v3_0_data.js');
+const { PLAIN_PROOF: ULTRAHONK_LEGACY_PLAIN_PROOF, PUBS: ULTRAHONK_LEGACY_PUBS, VK: ULTRAHONK_LEGACY_VK } = require('./ultrahonk_legacy_data.js');
 const { PROOF: ULTRAPLONK_PROOF, PUBS: ULTRAPLONK_PUBS, VK: ULTRAPLONK_VK } = require('./ultraplonk_data.js');
 const { PROOF: PLONKY2_PROOF, PUBS: PLONKY2_PUBS, VK: PLONKY2_VK } = require('./plonky2_data.js');
 const { PROOF: SP1_PROOF, PUBS: SP1_PUBS, VK: SP1_VK } = require('./sp1_data.js');
@@ -88,6 +89,11 @@ async function run(nodeName, networkInfo, _args) {
             name: "Ultrahonk.V.0.84 (Plain)",
             pallet: api.tx.settlementUltrahonkPallet,
             args: [{ 'Vk': ULTRAHONK_V0_84_VK }, ULTRAHONK_V0_84_PLAIN_PROOF, ULTRAHONK_V0_84_PUBS],
+        },
+        {
+            name: "Ultrahonk.Legacy (Plain)",
+            pallet: api.tx.settlementUltrahonkPallet,
+            args: [{ 'Vk': ULTRAHONK_LEGACY_VK }, ULTRAHONK_LEGACY_PLAIN_PROOF, ULTRAHONK_LEGACY_PUBS],
         },
         {
             name: "Ultraplonk",

--- a/zombienet-tests/js_scripts/ultrahonk_legacy_data.js
+++ b/zombienet-tests/js_scripts/ultrahonk_legacy_data.js
@@ -1,0 +1,26 @@
+// Legacy ultrahonk data: same raw proof/VK/pubs bytes as V0_84, wrapped in 'Legacy' variant.
+// This preserves backward compatibility with pre-versioning statement hashes.
+const v084 = require('./ultrahonk_v0_84_data.js');
+
+const ZK_PROOF = {
+    'Legacy': {
+        'ZK': v084.ZK_PROOF.V0_84.ZK
+    }
+};
+
+const PLAIN_PROOF = {
+    'Legacy': {
+        'Plain': v084.PLAIN_PROOF.V0_84.Plain
+    }
+};
+
+const PUBS = v084.PUBS;
+
+const VKEY = {
+    'Legacy': v084.VK.V0_84
+};
+
+exports.ZK_PROOF = ZK_PROOF;
+exports.PLAIN_PROOF = PLAIN_PROOF;
+exports.PUBS = PUBS;
+exports.VK = VKEY;

--- a/zombienet-tests/zkv-lib/index.js
+++ b/zombienet-tests/zkv-lib/index.js
@@ -32,7 +32,8 @@ zkvTypes = {
   UltrahonkVk: {
     _enum: {
       V0_84: 'Bytes',
-      V3_0: 'Bytes'
+      V3_0: 'Bytes',
+      Legacy: 'Bytes'
     }
   },
   FflonkVk: {


### PR DESCRIPTION
## Summary

Introduce a `Legacy` variant (codec index 2) for `VersionedProof` and `VersionedVk` that preserves the pre-versioning statement hash by:
- Using **SHA2-256** for VK hashing (matching the old `vk_hash` override)
- Returning raw VK bytes without the enum prefix (matching the old `vk_bytes`)
- Returning `NO_VERSION_HASH` from `verifier_version_hash`

This allows users who were using ultrahonk before the versioning commit (`83e40f29`) to submit proofs via the Legacy variant and get the same statement hash, avoiding the need to update their Solidity contracts.

Legacy uses the same V0_84 verification logic and proof/VK format.

## Changes

- **`verifiers/ultrahonk/src/lib.rs`**: Add `Legacy` to `VersionedProof`, `VersionedVk`, `ProtocolVersion`; update `verify_proof`, `validate_vk`, override `vk_hash`/`vk_bytes`/`verifier_version_hash`; update weights
- **`verifiers/ultrahonk/src/resources.rs`**: Add Legacy test data loading (reuses V0_84 data)
- **`verifiers/ultrahonk/src/verifier_should.rs`**: Add Legacy to all parameterized tests, version mismatch tests, VK hash regression test (`862d96a2...`), statement hash regression test using pre-versioning data from commit `113a728c`
- **`rpc/vk_hash/src/lib.rs`**: Add `Legacy` variant to RPC `UltrahonkVk` enum
- **`zombienet-tests/`**: Add Legacy test case to aggregate proofs E2E test, new `ultrahonk_legacy_data.js`, update `UltrahonkVk` type registry

## Testing

- All 72 ultrahonk unit tests pass (including 13 benchmarks)
- Clippy clean
- Full workspace `cargo check --all-features` passes