### PR TITLE
Bump runtime version to 1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20387,7 +20387,7 @@ dependencies = [
 
 [[package]]
 name = "zkv-runtime"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "aggregate-rpc-runtime-api",
  "anyhow",

--- a/runtime/zkverify/Cargo.toml
+++ b/runtime/zkverify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zkv-runtime"
-version = "1.6.0"
+version = "1.6.1"
 description = "zkVerify Runtime."
 authors.workspace = true
 homepage = "https://github.com/zkVerify/zkVerify"

--- a/runtime/zkverify/src/configs/commons.rs
+++ b/runtime/zkverify/src/configs/commons.rs
@@ -23,7 +23,7 @@ macro_rules! runtime_version {
             spec_name: Cow::Borrowed($spec_name),
             impl_name: Cow::Borrowed("zkv-node"),
             authoring_version: 1,
-            spec_version: 1_006_000,
+            spec_version: 1_006_001,
             impl_version: 1,
             apis: RUNTIME_API_VERSIONS,
             transaction_version: 1,


### PR DESCRIPTION
## Summary
- Bump `zkv-runtime` crate version from 1.6.0 to 1.6.1
- Update `spec_version` from `1_006_000` to `1_006_001`
- Cargo.lock updated accordingly

## Test plan
- [x] `cargo check` passes
- [x] `check_version` runtime test passes (confirms spec_version matches Cargo.toml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)