### PR TITLE
ci: build coverage with debug=0 to fix No space left on device

### DIFF
--- a/.github/workflows/CI-coverage.yml
+++ b/.github/workflows/CI-coverage.yml
@@ -18,7 +18,7 @@ jobs:
         uses: ./.github/actions/cmd-in-docker
         with:
           command: >-
-            /bin/bash -c 'set -o pipefail && cargo llvm-cov clean --workspace && find . -name \"*.profraw\" -delete
+            /bin/bash -c 'set -o pipefail && export CARGO_PROFILE_DEV_DEBUG=0 && cargo llvm-cov clean --workspace && find . -name \"*.profraw\" -delete
             && cargo llvm-cov --no-rustc-wrapper --all-features --workspace --exclude zkv-relay --exclude paratest-node --exclude test-service --lcov --output-path lcov.info
             && cargo llvm-cov report --json --output-path coverage_report.json --summary-only && cargo llvm-cov report | tee coverage_summary.txt'
           use_cache: 'yes'


### PR DESCRIPTION
## Problem

The Coverage job fails with:

```
No space left on device (os error 28)
```

`cargo llvm-cov --all-features --workspace` instruments the **entire** Substrate workspace in the `dev` profile. The root `Cargo.toml` has no `[profile.dev]` override, so it defaults to `debug = 2` (full DWARF). For a workspace this size, debug info is the single largest component of the `target/` tree — and the instrumented tree plus `.profraw` files, layered on the restored cache, exhausts the disk.

The WarpBuild runner can't be sized up: every Linux tier (2x–32x) ships a **fixed 150 GB SSD** that [cannot be modified](https://www.warpbuild.com/docs/ci/cloud-runners) — bumping the runner label adds CPU/RAM but no disk. So the fix has to reduce what the build writes.

(`CARGO_INCREMENTAL=0` is already set in `ci/entrypoint.sh`, so that lever was already in use.)

## Fix

Build coverage with `debug = 0`. LLVM source-based coverage embeds its line/region mapping in the binary's `__llvm_covmap` section and does **not** rely on DWARF, so dropping debug info removes the largest chunk of the target tree **with no loss of line/region coverage**.

Applied via the `CARGO_PROFILE_DEV_DEBUG=0` profile env var, scoped to the coverage command — not `RUSTFLAGS`, which `cargo-llvm-cov` manages itself for `-C instrument-coverage`.

```diff
- /bin/bash -c 'set -o pipefail && cargo llvm-cov clean --workspace ...
+ /bin/bash -c 'set -o pipefail && export CARGO_PROFILE_DEV_DEBUG=0 && cargo llvm-cov clean --workspace ...
```

Takes full effect once merged to the default branch (the restored `coverage-<branch>` cache shrinks after the first default-branch run).

## Follow-up if still tight

If a run still approaches 150 GB, the next step is to shard `--workspace` coverage across parallel jobs and merge the `lcov.info` files — a larger change, deferred unless needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)